### PR TITLE
Project completion active claims

### DIFF
--- a/src/Types.sol
+++ b/src/Types.sol
@@ -69,8 +69,9 @@ struct EngineStorage {
     mapping(bytes32 => uint256) originatorLockedStake;
     mapping(bytes32 => OriginatorReport) originatorReports;
 
-    // ── Pipeline Tracking (SEC-H-01) ─────────────────────────
+    // ── Pipeline Tracking (SEC-H-01 / POQ-1) ─────────────────
     mapping(bytes32 => uint256) pendingContributions;
+    mapping(bytes32 => uint256) activeContributionClaims;
 
     // ── Claim Protection ──────────────────────────────────────
     uint256 minClaimAmount;

--- a/src/libraries/ContributionLib.sol
+++ b/src/libraries/ContributionLib.sol
@@ -85,6 +85,7 @@ library ContributionLib {
             claim.deadline = uint48(block.timestamp + $.claimDeadline);
             claim.totalCount = uint16(quantity);
             claim.status = ClaimStatus.Active;
+            $.activeContributionClaims[projectId]++;
 
             if (adapter != address(0)) {
                 $.contributionAdapter[claimId] = adapter;
@@ -146,6 +147,9 @@ library ContributionLib {
         claim.submittedCount++;
         if (claim.submittedCount == claim.totalCount) {
             claim.status = ClaimStatus.Completed;
+            if ($.activeContributionClaims[projectId] > 0) {
+                $.activeContributionClaims[projectId]--;
+            }
         }
 
         emit ISapienCore.ContributionSubmitted(projectId, index, msg.sender, submissionHash, dataCid);
@@ -214,6 +218,9 @@ library ContributionLib {
         }
 
         claim.status = ClaimStatus.Expired;
+        if ($.activeContributionClaims[projectId] > 0) {
+            $.activeContributionClaims[projectId]--;
+        }
 
         if (unsubmitted > 0) {
             ReputationLib.update(claim.claimant, proj.requiredSkill, false, 0);

--- a/src/libraries/FinalizationLib.sol
+++ b/src/libraries/FinalizationLib.sol
@@ -238,7 +238,9 @@ library FinalizationLib {
             revert ISapienCore.ProjectNotActive();
         }
 
-        if ($.pendingContributions[projectId] > 0) revert ISapienCore.ProjectHasActivePipeline();
+        if ($.pendingContributions[projectId] > 0 || $.activeContributionClaims[projectId] > 0) {
+            revert ISapienCore.ProjectHasActivePipeline();
+        }
 
         proj.status = ProjectStatus.Completed;
         proj.completedAt = uint48(block.timestamp);

--- a/test/findings/2026-02-18/one/SEC_H_01_PrematureCompletion.t.sol
+++ b/test/findings/2026-02-18/one/SEC_H_01_PrematureCompletion.t.sol
@@ -10,6 +10,18 @@ import {ISapienCore} from "src/interfaces/ISapienCore.sol";
 /// @notice Verifies that completeProject reverts with ProjectHasActivePipeline when
 ///         contributions are in-flight, preventing escrow drain.
 contract SEC_H_01_PrematureCompletion is BaseTest {
+    function test_cannotCompleteWithActiveReservedClaim() public {
+        bytes32 projectId = _createAndFundProject();
+
+        // Contributor reserves a slot but has not submitted yet.
+        vm.prank(contributor1);
+        engine.claimToContribute(projectId, 1, adapter);
+
+        vm.prank(originator);
+        vm.expectRevert(ISapienCore.ProjectHasActivePipeline.selector);
+        engine.completeProject(projectId);
+    }
+
     function test_cannotCompleteWithInFlightContributions() public {
         bytes32 projectId = _createAndFundProject();
 

--- a/test/libraries/FinalizationLibFuzz.t.sol
+++ b/test/libraries/FinalizationLibFuzz.t.sol
@@ -335,6 +335,18 @@ contract FinalizationLibFuzz is Test {
         engine.completeProject(PROJECT_ID);
     }
 
+    function testFuzz_completeProject_revertsActiveReservedClaim() public {
+        _warpPastChallengePeriod();
+        engine.releaseContributorReward(PROJECT_ID, acceptedIndex);
+
+        vm.prank(contributor);
+        engine.claimToContribute(PROJECT_ID, 1, address(0));
+
+        vm.prank(originator);
+        vm.expectRevert(ISapienCore.ProjectHasActivePipeline.selector);
+        engine.completeProject(PROJECT_ID);
+    }
+
     function testFuzz_refundEscrow_afterCompletionDelay() public {
         _warpPastChallengePeriod();
         engine.releaseContributorReward(PROJECT_ID, acceptedIndex);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevent project completion while active contribution claims are reserved.

This addresses an audit finding (POQ-1) where projects could be completed even if contributors held active, reserved-but-unsubmitted claims, leading to premature finalization.

---
<p><a href="https://cursor.com/agents/bc-74dc892e-38b7-4da8-82bb-f5bdb6d6723c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74dc892e-38b7-4da8-82bb-f5bdb6d6723c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->