### PR TITLE
[POQ-4] Cancellation Paths Do Not Unwind Active Pipeline, Permanently…

### DIFF
--- a/src/libraries/FinalizationLib.sol
+++ b/src/libraries/FinalizationLib.sol
@@ -260,6 +260,20 @@ library FinalizationLib {
         if (vc.commitTimestamp == 0) revert ISapienCore.NotCommitted();
         if (vc.revealedAt != 0) revert ISapienCore.AlreadyRevealed();
 
+        // POQ-4: On cancelled projects, release stake instead of slashing.
+        // Committed-but-not-revealed validators should not be penalised for
+        // a project that was cancelled out from under them.
+        if ($.projects[projectId].status == ProjectStatus.Cancelled) {
+            if (vc.settled) revert ISapienCore.AlreadySettled();
+            vc.settled = true;
+            uint256 stake = vc.stakedAmount;
+            if (stake > 0) {
+                $.vault.releaseCommit(validator, stake);
+            }
+            emit ISapienCore.ValidatorSettled(projectId, index, validator, false);
+            return;
+        }
+
         if (block.timestamp <= vc.commitTimestamp + $.commitDeadline + $.revealDeadline) {
             revert ISapienCore.ClaimDeadlineNotPassed();
         }

--- a/src/libraries/FinalizationLib.sol
+++ b/src/libraries/FinalizationLib.sol
@@ -40,6 +40,13 @@ library FinalizationLib {
 
     function forceSettleValidator(bytes32 projectId, uint256 index, uint256 nonce, address validator) public {
         EngineStorage storage $ = _getStorage();
+
+        // POQ-4: On cancelled projects, skip consensus/reveal/delay checks
+        if ($.projects[projectId].status == ProjectStatus.Cancelled) {
+            _settleValidatorFor(projectId, index, nonce, validator);
+            return;
+        }
+
         ConsensusReport storage report = $.consensusReports[projectId][index][nonce];
         if (!report.computed) revert ISapienCore.ConsensusNotReady(0, 1);
 
@@ -56,7 +63,22 @@ library FinalizationLib {
         EngineStorage storage $ = _getStorage();
 
         Project storage proj = $.projects[projectId];
-        if (proj.status == ProjectStatus.Cancelled) revert ISapienCore.ProjectNotActive();
+
+        // POQ-4: On cancelled projects, release validator in-flight stake without rewards
+        if (proj.status == ProjectStatus.Cancelled) {
+            ValidatorCommit storage vc = $.validatorCommits[projectId][index][nonce][validator];
+            if (vc.settled) revert ISapienCore.AlreadySettled();
+            if (vc.commitHash == bytes32(0)) revert ISapienCore.NotCommitted();
+
+            vc.settled = true;
+            uint256 stake = vc.stakedAmount;
+            if (stake > 0) {
+                $.vault.releaseCommit(validator, stake);
+            }
+
+            emit ISapienCore.ValidatorSettled(projectId, index, validator, false);
+            return;
+        }
 
         {
             ConsensusReport storage report = $.consensusReports[projectId][index][nonce];

--- a/src/libraries/ValidationLib.sol
+++ b/src/libraries/ValidationLib.sol
@@ -89,6 +89,11 @@ library ValidationLib {
         EngineStorage storage $ = _getStorage();
         Project storage proj = $.projects[projectId];
 
+        // POQ-4: Block validation claims on non-active projects
+        if (proj.status != ProjectStatus.Active && proj.status != ProjectStatus.Funded) {
+            revert ISapienCore.ProjectNotActive();
+        }
+
         if (proj.minValidatorReputation > 0) {
             uint256 rep = ReputationLib.getScore(msg.sender, proj.requiredSkill);
             if (rep < proj.minValidatorReputation) {
@@ -141,6 +146,14 @@ library ValidationLib {
         address adapter
     ) public {
         EngineStorage storage $ = _getStorage();
+
+        // POQ-4: Block commits on cancelled/completed projects
+        {
+            ProjectStatus status = $.projects[projectId].status;
+            if (status == ProjectStatus.Cancelled || status == ProjectStatus.Completed) {
+                revert ISapienCore.ProjectNotActive();
+            }
+        }
 
         uint256 nonce = $.submissionNonce[projectId][index];
 
@@ -202,6 +215,15 @@ library ValidationLib {
         if (score > 10_000) revert ISapienCore.InvalidScore();
 
         EngineStorage storage $ = _getStorage();
+
+        // POQ-4: Block reveals on cancelled/completed projects
+        {
+            ProjectStatus status = $.projects[projectId].status;
+            if (status == ProjectStatus.Cancelled || status == ProjectStatus.Completed) {
+                revert ISapienCore.ProjectNotActive();
+            }
+        }
+
         uint256 nonce = $.submissionNonce[projectId][index];
 
         ValidatorCommit storage vc = $.validatorCommits[projectId][index][nonce][msg.sender];

--- a/test/findings/2026-02-24/SECURITY_FINDINGS_VERIFICATION.t.sol
+++ b/test/findings/2026-02-24/SECURITY_FINDINGS_VERIFICATION.t.sol
@@ -276,11 +276,16 @@ contract SecurityFindings_2026_02_24 is BaseTest {
         vm.expectRevert(ISapienCore.ChallengeNotElapsed.selector);
         engine.refundEscrow(pid);
 
-        // Validators CAN settle during the delay window
+        // POQ-4: Validators CAN settle during the delay window (stake released, no rewards)
         _warpPastChallengePeriod();
+        uint256 inFlightBefore = vault.getStakeAccount(validator1).inFlight;
+        assertGt(inFlightBefore, 0, "validator has in-flight stake before settlement");
+
         vm.prank(validator1);
-        vm.expectRevert(ISapienCore.ProjectNotActive.selector);
         engine.settleValidator(pid, idx, 0);
+
+        assertEq(vault.getStakeAccount(validator1).inFlight, 0, "validator stake released after settlement");
+        assertEq(engine.getPendingRewards(validator1, address(token)), 0, "no reward on cancelled project");
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -328,10 +333,11 @@ contract SecurityFindings_2026_02_24 is BaseTest {
     }
 
     // ════════════════════════════════════════════════════════════════════
-    // SEC-M-03 FIX: Settlement reverts on cancelled projects
+    // SEC-M-03 / POQ-4: Settlement on cancelled projects releases stake without rewards
     // ════════════════════════════════════════════════════════════════════
 
-    /// @notice FIX: Settlement and reward release now revert on cancelled projects.
+    /// @notice POQ-4 supersedes SEC-M-03: Settlement on cancelled projects now succeeds
+    ///         but only releases the validator's committed stake — no rewards are paid.
     function test_SEC_M_03_settlementProceedsOnCancelledProject() public {
         bytes32 pid = _createSimpleProject(keccak256("m03"), 1_000e18, 1);
         (, uint256[] memory indices) = _claimAndContributeSimple(contributor1, pid, 1);
@@ -347,12 +353,16 @@ contract SecurityFindings_2026_02_24 is BaseTest {
         engine.removeProject(pid);
         assertEq(uint256(engine.getProject(pid).status), uint256(ProjectStatus.Cancelled));
 
-        // FIX: Settlement now reverts with ProjectNotActive
+        // POQ-4: Settlement succeeds — stake is released, no rewards paid
+        uint256 inFlightBefore = vault.getStakeAccount(validator1).inFlight;
+        assertGt(inFlightBefore, 0, "validator has in-flight stake");
+
         vm.prank(validator1);
-        vm.expectRevert(ISapienCore.ProjectNotActive.selector);
         engine.settleValidator(pid, idx, 0);
 
-        assertFalse(engine.isValidatorSettled(pid, idx, 0, validator1), "cannot settle on cancelled project");
+        assertTrue(engine.isValidatorSettled(pid, idx, 0, validator1), "validator should be settled");
+        assertEq(vault.getStakeAccount(validator1).inFlight, 0, "in-flight stake released");
+        assertEq(engine.getPendingRewards(validator1, address(token)), 0, "no reward on cancelled project");
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/test/findings/2026-03-09/POQ_004_ValidatorFundsCancellation.t.sol
+++ b/test/findings/2026-03-09/POQ_004_ValidatorFundsCancellation.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {BaseTest} from "test/BaseTest.sol";
+import {Project, ProjectStatus, StakeAccount, ContributionStatus} from "src/Types.sol";
+import {ISapienCore} from "src/interfaces/ISapienCore.sol";
+import {Constants as C} from "src/Constants.sol";
+
+/// @title POQ-4: Cancellation Paths Do Not Unwind Active Pipeline, Permanently Stranding Validator Funds
+/// @notice Tests that validator in-flight stakes are recoverable after project cancellation
+///         and that status guards prevent new validators from entering cancelled projects.
+contract POQ_004_ValidatorFundsCancellation is BaseTest {
+    bytes32 constant PID = keccak256("poq4-test");
+
+    function _createSmallProject() internal returns (bytes32) {
+        return _createAndFundProject(PID, FUND_AMOUNT, 2);
+    }
+
+    function _fullValidationFlow(bytes32 projectId, uint256 index) internal {
+        _commitAndReveal(validator1, projectId, index, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator2, projectId, index, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator3, projectId, index, 8000, VALIDATOR_STAKE);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: Validator settlement works on cancelled projects (removeProject)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_settleValidator_afterRemoveProject() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _fullValidationFlow(projectId, idx);
+        engine.computeConsensus(projectId, idx);
+
+        StakeAccount memory v1Before = vault.getStakeAccount(validator1);
+        StakeAccount memory v2Before = vault.getStakeAccount(validator2);
+        StakeAccount memory v3Before = vault.getStakeAccount(validator3);
+
+        assertGt(v1Before.inFlight, 0, "v1 should have in-flight stake");
+        assertGt(v2Before.inFlight, 0, "v2 should have in-flight stake");
+        assertGt(v3Before.inFlight, 0, "v3 should have in-flight stake");
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        assertEq(
+            uint256(engine.getProject(projectId).status),
+            uint256(ProjectStatus.Cancelled),
+            "project should be cancelled"
+        );
+
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        vm.prank(validator2);
+        engine.settleValidator(projectId, idx, 0);
+
+        vm.prank(validator3);
+        engine.settleValidator(projectId, idx, 0);
+
+        StakeAccount memory v1After = vault.getStakeAccount(validator1);
+        StakeAccount memory v2After = vault.getStakeAccount(validator2);
+        StakeAccount memory v3After = vault.getStakeAccount(validator3);
+
+        assertEq(v1After.inFlight, 0, "v1 in-flight should be 0 after settlement");
+        assertEq(v2After.inFlight, 0, "v2 in-flight should be 0 after settlement");
+        assertEq(v3After.inFlight, 0, "v3 in-flight should be 0 after settlement");
+
+        assertEq(
+            v1After.validatorCapacity,
+            v1Before.validatorCapacity + v1Before.inFlight,
+            "v1 capacity should include released stake"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: Validator settlement works on cancelled projects (upholdOriginatorReport)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_settleValidator_afterUpholdOriginatorReport() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _fullValidationFlow(projectId, idx);
+        engine.computeConsensus(projectId, idx);
+
+        StakeAccount memory v1Before = vault.getStakeAccount(validator1);
+        assertGt(v1Before.inFlight, 0, "v1 should have in-flight stake");
+
+        _ensureStake(contributor2, 1000e18);
+        vm.prank(contributor2);
+        engine.reportOriginator(projectId, keccak256("evidence"));
+
+        vm.prank(admin);
+        engine.resolveOriginatorReport(projectId, true);
+
+        assertEq(
+            uint256(engine.getProject(projectId).status),
+            uint256(ProjectStatus.Cancelled),
+            "project should be cancelled"
+        );
+
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        StakeAccount memory v1After = vault.getStakeAccount(validator1);
+        assertEq(v1After.inFlight, 0, "v1 in-flight should be 0 after settlement");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: forceSettleValidator works on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_forceSettleValidator_afterCancellation() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _fullValidationFlow(projectId, idx);
+        engine.computeConsensus(projectId, idx);
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        engine.forceSettleValidator(projectId, idx, 0, validator1);
+
+        StakeAccount memory v1After = vault.getStakeAccount(validator1);
+        assertEq(v1After.inFlight, 0, "v1 in-flight should be 0 after force settlement");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: Committed-but-not-revealed validators can settle on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_settleCommittedNotRevealed_afterCancellation() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, idx));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.startPrank(validator1);
+        engine.claimToValidate(projectId, 1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        engine.commitValidation(projectId, idx, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+
+        StakeAccount memory v1Before = vault.getStakeAccount(validator1);
+        assertGt(v1Before.inFlight, 0, "v1 should have in-flight stake");
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        StakeAccount memory v1After = vault.getStakeAccount(validator1);
+        assertEq(v1After.inFlight, 0, "v1 in-flight should be 0");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: claimToValidate is blocked on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_claimToValidate_blockedOnCancelledProject() public {
+        bytes32 projectId = _createSmallProject();
+
+        _claimAndContribute(contributor1, projectId, 1);
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        vm.prank(validator1);
+        vm.expectRevert(ISapienCore.ProjectNotActive.selector);
+        engine.claimToValidate(projectId, 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: commitValidation is blocked on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_commitValidation_blockedOnCancelledProject() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.prank(validator1);
+        engine.claimToValidate(projectId, 1);
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, idx));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        vm.startPrank(validator1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        vm.expectRevert(ISapienCore.ProjectNotActive.selector);
+        engine.commitValidation(projectId, idx, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: revealValidation is blocked on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_revealValidation_blockedOnCancelledProject() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, idx));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.startPrank(validator1);
+        engine.claimToValidate(projectId, 1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        engine.commitValidation(projectId, idx, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        vm.prank(validator1);
+        vm.expectRevert(ISapienCore.ProjectNotActive.selector);
+        engine.revealValidation(projectId, idx, 8000, salt);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: No rewards paid to validators on cancelled project settlement
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_noRewards_onCancelledProjectSettlement() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _fullValidationFlow(projectId, idx);
+        engine.computeConsensus(projectId, idx);
+
+        uint256 v1RewardsBefore = engine.getPendingRewards(validator1, address(token));
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        _warpPastChallengePeriod();
+
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        uint256 v1RewardsAfter = engine.getPendingRewards(validator1, address(token));
+        assertEq(v1RewardsAfter, v1RewardsBefore, "no rewards should be paid on cancelled project");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test: Double settlement is still prevented on cancelled projects
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_POQ4_doubleSettlement_reverts() public {
+        bytes32 projectId = _createSmallProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        _fullValidationFlow(projectId, idx);
+        engine.computeConsensus(projectId, idx);
+
+        vm.prank(admin);
+        engine.removeProject(projectId);
+
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        vm.prank(validator1);
+        vm.expectRevert(ISapienCore.AlreadySettled.selector);
+        engine.settleValidator(projectId, idx, 0);
+    }
+}

--- a/test/findings/2026-03-11/POQ_004_CancelExpiredCommitmentSlashOnCancelledProject.t.sol
+++ b/test/findings/2026-03-11/POQ_004_CancelExpiredCommitmentSlashOnCancelledProject.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {BaseTest} from "test/BaseTest.sol";
+import {StakeAccount, ProjectStatus} from "src/Types.sol";
+import {ISapienCore} from "src/interfaces/ISapienCore.sol";
+
+/// @title POQ-004: cancelExpiredCommitment slashes validators on cancelled projects
+/// @notice A committed-but-not-revealed validator whose project gets cancelled should
+///         have their stake released, not slashed.  Before the fix, a third party could
+///         call cancelExpiredCommitment after the reveal window and fully slash the
+///         validator — the same fund-stranding scenario POQ-4 set out to eliminate.
+contract POQ_004_CancelExpiredCommitmentSlashOnCancelledProject is BaseTest {
+    /// @notice On a cancelled project, cancelExpiredCommitment releases stake
+    ///         instead of slashing.
+    function test_cancelExpiredCommitment_releasesOnCancelledProject() public {
+        bytes32 pid = _createAndFundProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, pid, 1);
+        uint256 index = indices[0];
+
+        // validator1 commits but does NOT reveal
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, index));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.startPrank(validator1);
+        engine.claimToValidate(pid, 1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        engine.commitValidation(pid, index, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+
+        StakeAccount memory before = vault.getStakeAccount(validator1);
+        assertGt(before.inFlight, 0, "validator has in-flight stake after commit");
+
+        // Operator cancels the project
+        vm.prank(admin);
+        engine.removeProject(pid);
+        assertEq(uint256(engine.getProject(pid).status), uint256(ProjectStatus.Cancelled));
+
+        // Warp past the full commit+reveal window so the commitment is "expired"
+        vm.warp(block.timestamp + engine.commitDeadline() + engine.revealDeadline() + 1);
+
+        // Anyone calls cancelExpiredCommitment — should release, not slash
+        uint256 sharesBefore = vault.balanceOf(validator1);
+
+        vm.expectEmit(true, true, true, true);
+        emit ISapienCore.ValidatorSettled(pid, index, validator1, false);
+
+        engine.cancelExpiredCommitment(pid, index, validator1);
+
+        StakeAccount memory after_ = vault.getStakeAccount(validator1);
+        assertEq(after_.inFlight, 0, "in-flight stake released");
+
+        uint256 sharesAfter = vault.balanceOf(validator1);
+        assertEq(sharesAfter, sharesBefore, "no shares burned - stake was released, not slashed");
+    }
+
+    /// @notice On a cancelled project, cancelExpiredCommitment reverts if already
+    ///         settled via settleValidator.
+    function test_cancelExpiredCommitment_revertsIfAlreadySettled() public {
+        bytes32 pid = _createAndFundProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, pid, 1);
+        uint256 index = indices[0];
+
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, index));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.startPrank(validator1);
+        engine.claimToValidate(pid, 1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        engine.commitValidation(pid, index, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+
+        vm.prank(admin);
+        engine.removeProject(pid);
+
+        // Validator settles first via the POQ-4 pull path
+        vm.prank(validator1);
+        engine.settleValidator(pid, index, 0);
+
+        // Now cancelExpiredCommitment should revert
+        vm.warp(block.timestamp + engine.commitDeadline() + engine.revealDeadline() + 1);
+        vm.expectRevert(ISapienCore.AlreadySettled.selector);
+        engine.cancelExpiredCommitment(pid, index, validator1);
+    }
+
+    /// @notice On an ACTIVE project, cancelExpiredCommitment still slashes as before.
+    function test_cancelExpiredCommitment_stillSlashesOnActiveProject() public {
+        bytes32 pid = _createAndFundProject();
+
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, pid, 1);
+        uint256 index = indices[0];
+
+        bytes32 salt = keccak256(abi.encodePacked("salt", validator1, index));
+        bytes32 commitHash = keccak256(abi.encodePacked(uint256(8000), salt));
+
+        _ensureStake(validator1, VALIDATOR_STAKE * 2);
+        vm.startPrank(validator1);
+        engine.claimToValidate(pid, 1);
+        engine.lockValidatorCapacity(VALIDATOR_STAKE);
+        engine.commitValidation(pid, index, commitHash, VALIDATOR_STAKE, address(0));
+        vm.stopPrank();
+
+        // Project stays active — warp past the window
+        vm.warp(block.timestamp + engine.commitDeadline() + engine.revealDeadline() + 1);
+
+        uint256 sharesBefore = vault.balanceOf(validator1);
+
+        engine.cancelExpiredCommitment(pid, index, validator1);
+
+        uint256 sharesAfter = vault.balanceOf(validator1);
+        assertLt(sharesAfter, sharesBefore, "validator slashed on active project");
+    }
+}


### PR DESCRIPTION
… Stranding Validator Funds

Fix:
- FinalizationLib: _settleValidatorFor() now handles cancelled projects by releasing validator in-flight stake without rewards or slashing. Supports both revealed and committed-but-not-revealed validators.
- FinalizationLib: forceSettleValidator() bypasses consensus/reveal/delay checks on cancelled projects, delegating directly to _settleValidatorFor().
- ValidationLib: Added project status guards to claimToValidate(), commitValidation(), and revealValidation() to prevent new validators from entering cancelled or completed projects.
- Updated SEC-H-03 and SEC-M-03 tests to reflect new behavior where settlement succeeds on cancelled projects (stake released, no rewards).

Tests:
- 9 new tests in POQ_004_ValidatorFundsCancellation.t.sol covering:
  - Settlement after removeProject and upholdOriginatorReport
  - forceSettleValidator on cancelled projects
  - Committed-but-not-revealed validator recovery
  - Status guards blocking claimToValidate, commitValidation, revealValidation
  - No rewards paid on cancelled project settlement
  - Double settlement prevention on cancelled projects