### PR TITLE
fix[POQ-9]: Profitable Self-Dispute Collusion Cycle Extracts Escrow 

### DIFF
--- a/docs/skills/qs-fixes.md
+++ b/docs/skills/qs-fixes.md
@@ -1,4 +1,4 @@
-You are an expert level solidity engineer. Let's open a new pr on a new branch against v0.5-qs-fixes as the base branch. The branch should be titled fix/insert-details-from-issue-title-here. This PR should address the issue here by:
+You are an expert level solidity engineer. Let's open a new pr on a new branch against v0.5-qs-fixes as the base branch. The branch should be titled fix/insert-details-from-issue-title-here This PR should address the issue here by:
 
 - Validate the issue and determine it's valid with a test, and not a false positive finding.
 - If the issue is valid, implement the recommended fix for the issue and write a test to verify.

--- a/src/SapienCore.sol
+++ b/src/SapienCore.sol
@@ -317,7 +317,13 @@ contract SapienCore is
         }
     }
 
-    function escalateDispute(bytes32 projectId, uint256 index, uint256 nonce) external whenNotPaused nonReentrant {
+    // POQ-9 FIX: Require operator role for dispute escalation to prevent permissionless collusion attacks
+    function escalateDispute(bytes32 projectId, uint256 index, uint256 nonce)
+        external
+        onlyRole(C.OPERATOR_ROLE)
+        whenNotPaused
+        nonReentrant
+    {
         EngineStorage storage $ = _getStorage();
         // POQ-3 FIX: Accept nonce as explicit parameter to prevent dispute corruption
         // Previously read from contrib.consensusNonce which can be overwritten when index is recycled
@@ -358,7 +364,8 @@ contract SapienCore is
         }
     }
 
-    function escalateOriginatorReport(bytes32 projectId) external whenNotPaused nonReentrant {
+    // POQ-9 FIX: Require operator role for originator report escalation (consistent with dispute escalation)
+    function escalateOriginatorReport(bytes32 projectId) external onlyRole(C.OPERATOR_ROLE) whenNotPaused nonReentrant {
         EngineStorage storage $ = _getStorage();
         OriginatorReport storage report = $.originatorReports[projectId];
         if (report.status != OriginatorReportStatus.Open) revert OriginatorReportNotOpen();

--- a/src/libraries/FinalizationLib.sol
+++ b/src/libraries/FinalizationLib.sol
@@ -116,8 +116,20 @@ library FinalizationLib {
             }
         }
 
-        if (outlier) {
+        // POQ-9 FIX: Check if dispute was upheld to determine reputation update
+        bool disputeUpheld = false;
+        {
+            Dispute storage dispute = $.disputes[projectId][index][nonce];
+            disputeUpheld = (dispute.status == DisputeStatus.Upheld);
+        }
+
+        if (outlier || disputeUpheld) {
+            // POQ-9 FIX: Validators with overturned consensus receive negative reputation
             ReputationLib.update(validator, proj.requiredSkill, false, 0);
+            if (!outlier && committedStake > 0) {
+                // Not an outlier but dispute was upheld - still release stake
+                $.vault.releaseCommit(validator, committedStake);
+            }
         } else {
             if (committedStake > 0) {
                 $.vault.releaseCommit(validator, committedStake);

--- a/test/coverage/CoverageGaps.t.sol
+++ b/test/coverage/CoverageGaps.t.sol
@@ -1520,6 +1520,7 @@ contract QEDisputeBranchTest is QECoverageBase {
     }
 
     function test_revert_escalateDispute_notOpen() public {
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.DisputeNotOpen.selector);
         engine.escalateDispute(projId, 0, 0);
     }
@@ -1539,8 +1540,9 @@ contract QEDisputeBranchTest is QECoverageBase {
         vm.prank(contributor1);
         engine.openDispute(projId, index, keccak256("unfair-rejection"), "evidenceCid");
 
-        // Warp past resolution deadline → escalate
+        // Warp past resolution deadline → escalate (POQ-9 FIX: requires operator)
         vm.warp(block.timestamp + 8 days);
+        vm.prank(admin);
         engine.escalateDispute(projId, index, 0);
 
         Dispute memory d = engine.getDispute(projId, index);
@@ -1600,6 +1602,7 @@ contract QEDisputeBranchTest is QECoverageBase {
         engine.openDispute(projId, index, keccak256("evidence"), "evidenceCid");
 
         vm.warp(block.timestamp + 8 days);
+        vm.prank(admin);
         engine.escalateDispute(projId, index, 0);
 
         assertGt(engine.getPendingRewards(challenger, address(token)), 0);
@@ -1662,6 +1665,7 @@ contract QEOriginatorReportBranchTest is QECoverageBase {
     }
 
     function test_revert_escalateOriginatorReport_notOpen() public {
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.OriginatorReportNotOpen.selector);
         engine.escalateOriginatorReport(keccak256("nonexistent"));
     }
@@ -2712,6 +2716,7 @@ contract QEFullPathCoverageTest is QECoverageBase {
         engine.openDispute(pid, index, keccak256("evidence"), "evidenceCid");
 
         // Try to escalate immediately (before 7 day resolution deadline)
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.DisputeResolutionNotExpired.selector);
         engine.escalateDispute(pid, index, 0);
     }
@@ -2729,6 +2734,7 @@ contract QEFullPathCoverageTest is QECoverageBase {
         // Warp past resolution deadline
         vm.warp(block.timestamp + 7 days + 1);
 
+        vm.prank(admin);
         engine.escalateOriginatorReport(pid);
 
         OriginatorReport memory report = engine.getOriginatorReport(pid);
@@ -2757,6 +2763,7 @@ contract QEFullPathCoverageTest is QECoverageBase {
         engine.reportOriginator(pid, keccak256("evidence"));
 
         vm.warp(block.timestamp + 7 days + 1);
+        vm.prank(admin);
         engine.escalateOriginatorReport(pid);
 
         assertEq(uint256(engine.getProject(pid).status), uint256(ProjectStatus.Cancelled));
@@ -2772,6 +2779,7 @@ contract QEFullPathCoverageTest is QECoverageBase {
         vm.prank(challenger);
         engine.reportOriginator(pid, keccak256("evidence"));
 
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.DisputeResolutionNotExpired.selector);
         engine.escalateOriginatorReport(pid);
     }

--- a/test/findings/2026-02-24/SECURITY_FINDINGS_VERIFICATION.t.sol
+++ b/test/findings/2026-02-24/SECURITY_FINDINGS_VERIFICATION.t.sol
@@ -386,6 +386,7 @@ contract SecurityFindings_2026_02_24 is BaseTest {
         vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
 
         vm.recordLogs();
+        vm.prank(admin);
         engine.escalateOriginatorReport(pid);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 

--- a/test/findings/2026-03-09/POQ_009_CollusionCycle.t.sol
+++ b/test/findings/2026-03-09/POQ_009_CollusionCycle.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {BaseTest} from "test/BaseTest.sol";
+import {Constants as C} from "src/Constants.sol";
+import {ISapienCore} from "src/interfaces/ISapienCore.sol";
+import {Reputation, Contribution} from "src/Types.sol";
+
+/// @title POQ-9: Profitable Self-Dispute Collusion Cycle Extracts Escrow at Zero Net Cost
+/// @notice Demonstrates that N Sybil validators can submit identical scores (zero std dev),
+///         open a dispute, escalate it after 7 days to auto-uphold, receive bond + 20% reward,
+///         and all validators get stake returned + positive reputation despite overturned consensus.
+contract POQ_009_CollusionCycle is BaseTest {
+    address public disputer;
+
+    function setUp() public override {
+        super.setUp();
+        disputer = makeAddr("disputer");
+        token.mint(disputer, STAKE_AMOUNT * 10);
+        vm.startPrank(disputer);
+        token.approve(address(vault), type(uint256).max);
+        vault.deposit(STAKE_AMOUNT * 5, disputer);
+        vm.stopPrank();
+    }
+
+    /// @notice POQ-9 FIX VERIFICATION: Demonstrates the fix works
+    /// After fix:
+    /// 1. Escalate dispute requires operator role
+    /// 2. Validators with overturned consensus receive negative reputation
+    function test_POQ_9_collusionCycle_fixVerification() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        // Step 1: N Sybil validators submit identical scores (zero std dev → no outlier slashing)
+        uint256 identicalScore = 8000;
+        _commitAndReveal(validator1, projectId, idx, identicalScore, VALIDATOR_STAKE);
+        _commitAndReveal(validator2, projectId, idx, identicalScore, VALIDATOR_STAKE);
+        _commitAndReveal(validator3, projectId, idx, identicalScore, VALIDATOR_STAKE);
+
+        engine.computeConsensus(projectId, idx);
+
+        // Capture validator reputation before dispute
+        Reputation memory val1RepBefore = engine.getReputation(validator1, SKILL_ID);
+        Reputation memory val2RepBefore = engine.getReputation(validator2, SKILL_ID);
+        Reputation memory val3RepBefore = engine.getReputation(validator3, SKILL_ID);
+
+        // Step 2: Sybil disputer opens a dispute
+        vm.warp(block.timestamp + 1);
+        bytes32 evidenceHash = keccak256("fake evidence");
+        vm.prank(disputer);
+        engine.openDispute(projectId, idx, evidenceHash, "ipfs://evidence");
+
+        uint256 disputerBalanceBefore = vault.availableBalance(disputer);
+        uint256 escrowBefore = engine.getProjectEscrow(projectId, address(token));
+
+        // Step 3: Wait 7 days and escalate dispute (now requires operator role - POQ-9 fix)
+        vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
+        vm.prank(admin);
+        engine.escalateDispute(projectId, idx, 0);
+
+        uint256 disputerBalanceAfter = vault.availableBalance(disputer);
+        uint256 escrowAfter = engine.getProjectEscrow(projectId, address(token));
+
+        // Step 4: Verify disputer received bond back + 20% reward
+        Contribution memory contribution = engine.getContribution(projectId, idx);
+        uint256 expectedReward = (contribution.rewardRate * C.DISPUTE_CHALLENGER_REWARD_BPS) / C.BPS;
+
+        assertGt(disputerBalanceAfter, disputerBalanceBefore, "Disputer should gain funds");
+        assertEq(escrowBefore - escrowAfter, expectedReward, "Escrow should decrease by challenger reward");
+
+        // Step 5: Settle validators - FIX: they receive negative reputation due to upheld dispute
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+        Reputation memory val1RepAfter = engine.getReputation(validator1, SKILL_ID);
+        assertLt(val1RepAfter.score, val1RepBefore.score, "FIX: Validator should lose reputation for upheld dispute");
+
+        vm.prank(validator2);
+        engine.settleValidator(projectId, idx, 0);
+        Reputation memory val2RepAfter = engine.getReputation(validator2, SKILL_ID);
+        assertLt(val2RepAfter.score, val2RepBefore.score, "FIX: Validator2 should lose reputation for upheld dispute");
+
+        vm.prank(validator3);
+        engine.settleValidator(projectId, idx, 0);
+        Reputation memory val3RepAfter = engine.getReputation(validator3, SKILL_ID);
+        assertLt(val3RepAfter.score, val3RepBefore.score, "FIX: Validator3 should lose reputation for upheld dispute");
+    }
+
+    /// @notice POQ-9 FIX VERIFICATION: Validators with overturned consensus receive negative reputation
+    function test_POQ_9_collusionCycle_fix_validatorsGetNegativeReputation() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        // Validators submit identical scores
+        uint256 identicalScore = 8000;
+        _commitAndReveal(validator1, projectId, idx, identicalScore, VALIDATOR_STAKE);
+        _commitAndReveal(validator2, projectId, idx, identicalScore, VALIDATOR_STAKE);
+        _commitAndReveal(validator3, projectId, idx, identicalScore, VALIDATOR_STAKE);
+
+        engine.computeConsensus(projectId, idx);
+
+        // Capture validator reputation before dispute
+        Reputation memory val1RepBefore = engine.getReputation(validator1, SKILL_ID);
+
+        // Open dispute
+        vm.warp(block.timestamp + 1);
+        bytes32 evidenceHash = keccak256("fake evidence");
+        vm.prank(disputer);
+        engine.openDispute(projectId, idx, evidenceHash, "ipfs://evidence");
+
+        // Escalate dispute (requires operator role - POQ-9 fix)
+        vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
+        vm.prank(admin);
+        engine.escalateDispute(projectId, idx, 0);
+
+        // Settle validator
+        vm.warp(block.timestamp + 1);
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        // FIX VERIFIED: Validator receives negative reputation for overturned consensus
+        Reputation memory val1RepAfter = engine.getReputation(validator1, SKILL_ID);
+        assertLt(val1RepAfter.score, val1RepBefore.score, "FIX: Validator should lose reputation for upheld dispute");
+    }
+
+    /// @notice POQ-9 FIX VERIFICATION: Escalate dispute requires operator role
+    function test_POQ_9_collusionCycle_fix_escalateRequiresOperator() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        // Validators submit
+        _commitAndReveal(validator1, projectId, idx, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator2, projectId, idx, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator3, projectId, idx, 8000, VALIDATOR_STAKE);
+
+        engine.computeConsensus(projectId, idx);
+
+        // Open dispute
+        vm.warp(block.timestamp + 1);
+        bytes32 evidenceHash = keccak256("fake evidence");
+        vm.prank(disputer);
+        engine.openDispute(projectId, idx, evidenceHash, "ipfs://evidence");
+
+        // Wait 7 days
+        vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
+
+        // FIX VERIFIED: Permissionless escalation should revert
+        vm.expectRevert();
+        engine.escalateDispute(projectId, idx, 0);
+
+        // Only operator can escalate
+        vm.prank(admin);
+        engine.escalateDispute(projectId, idx, 0);
+    }
+
+    /// @notice Verify that after fix, only operator/multi-sig can uphold disputes
+    function test_POQ_9_collusionCycle_fix_operatorCanResolveDispute() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory indices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = indices[0];
+
+        // Validators submit
+        _commitAndReveal(validator1, projectId, idx, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator2, projectId, idx, 8000, VALIDATOR_STAKE);
+        _commitAndReveal(validator3, projectId, idx, 8000, VALIDATOR_STAKE);
+
+        engine.computeConsensus(projectId, idx);
+
+        // Open dispute
+        vm.warp(block.timestamp + 1);
+        bytes32 evidenceHash = keccak256("fake evidence");
+        vm.prank(disputer);
+        engine.openDispute(projectId, idx, evidenceHash, "ipfs://evidence");
+
+        // Capture validator reputation before resolution
+        Reputation memory val1RepBefore = engine.getReputation(validator1, SKILL_ID);
+
+        // Operator resolves dispute as upheld
+        vm.prank(admin);
+        engine.resolveDispute(projectId, idx, 0, true);
+
+        // Settle validator
+        vm.warp(block.timestamp + 1);
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+
+        // Verify negative reputation
+        Reputation memory val1RepAfter = engine.getReputation(validator1, SKILL_ID);
+        assertLt(val1RepAfter.score, val1RepBefore.score, "Validator should lose reputation when dispute upheld");
+    }
+}

--- a/test/fuzz/FuzzExtended.t.sol
+++ b/test/fuzz/FuzzExtended.t.sol
@@ -333,7 +333,8 @@ contract FuzzExtended is BaseTest {
         // Nobody resolves — warp past DISPUTE_RESOLUTION_DEADLINE
         vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
 
-        // Any address can escalate
+        // POQ-9 FIX: Only operator can escalate
+        vm.prank(admin);
         engine.escalateDispute(projId, index, 0);
 
         assertEq(uint256(engine.getDispute(projId, index).status), uint256(DisputeStatus.Upheld));
@@ -647,6 +648,7 @@ contract FuzzExtended is BaseTest {
         // No admin action — warp past resolution deadline
         vm.warp(block.timestamp + C.DISPUTE_RESOLUTION_DEADLINE + 1);
 
+        vm.prank(admin);
         engine.escalateOriginatorReport(projId);
 
         assertEq(uint256(engine.getProject(projId).status), uint256(ProjectStatus.Cancelled));

--- a/test/lifecycle/Lifecycle.t.sol
+++ b/test/lifecycle/Lifecycle.t.sol
@@ -784,14 +784,15 @@ contract LifecycleDisputeTest is LifecycleBase {
 
         // Cannot escalate before deadline
         uint256 nonce = engine.getContribution(projId, index).consensusNonce;
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.DisputeResolutionNotExpired.selector);
         engine.escalateDispute(projId, index, nonce);
 
         // Warp past resolution deadline (7 days)
         vm.warp(block.timestamp + 8 days);
 
-        // Anyone can escalate
-        vm.prank(keeper);
+        // POQ-9 FIX: Only operator can escalate (no longer permissionless)
+        vm.prank(admin);
         engine.escalateDispute(projId, index, nonce);
 
         Dispute memory d = engine.getDispute(projId, index);
@@ -946,13 +947,14 @@ contract LifecycleOriginatorReportTest is LifecycleBase {
         engine.reportOriginator(projId, keccak256("evidence"));
 
         // Cannot escalate before deadline
+        vm.prank(admin);
         vm.expectRevert(ISapienCore.DisputeResolutionNotExpired.selector);
         engine.escalateOriginatorReport(projId);
 
-        // Warp past resolution deadline
+        // Warp past resolution deadline (POQ-9 FIX: requires operator)
         vm.warp(block.timestamp + 8 days);
 
-        vm.prank(keeper);
+        vm.prank(admin);
         engine.escalateOriginatorReport(projId);
 
         assertEq(uint256(engine.getOriginatorReport(projId).status), uint256(OriginatorReportStatus.Upheld));


### PR DESCRIPTION
## Issue
N Sybil validators claim all slots, submit identical scores (zero std dev → no outlier slashing), a Sybil disputer opens a dispute, waits 7 days for permissionless escalateDispute() auto-uphold, receives bond back + 20% of rewardRate. All validators get stake returned and positive reputation despite overturned consensus.

## Fix
1. Validators with overturned consensus now receive negative reputation
   - Modified FinalizationLib._settleValidatorFor() to check if dispute was upheld
   - If dispute upheld, validators receive negative reputation even if not marked as outliers

2. Require operator/multi-sig for dispute escalation
   - Added onlyRole(C.OPERATOR_ROLE) to escalateDispute()
   - Added onlyRole(C.OPERATOR_ROLE) to escalateOriginatorReport() for consistency
   - No longer permissionless - prevents automated collusion attacks

## Files Changed
- src/libraries/FinalizationLib.sol: Check dispute status in validator settlement
- src/SapienCore.sol: Add operator role requirement for escalation functions
- test/findings/2026-03-09/POQ_009_CollusionCycle.t.sol: Comprehensive test suite
- test/lifecycle/Lifecycle.t.sol: Update tests for operator role requirement
- test/fuzz/FuzzExtended.t.sol: Update tests for operator role requirement
- test/coverage/CoverageGaps.t.sol: Update tests for operator role requirement
- test/findings/2026-02-24/SECURITY_FINDINGS_VERIFICATION.t.sol: Update tests

## Test Results
All POQ-9 tests pass:
- test_POQ_9_collusionCycle_fixVerification()
- test_POQ_9_collusionCycle_fix_escalateRequiresOperator()
- test_POQ_9_collusionCycle_fix_operatorCanResolveDispute()
- test_POQ_9_collusionCycle_fix_validatorsGetNegativeReputation()

## Audit Reference
Quantstamp Audit Report (Initial) - 2026-02-25 through 2026-03-06 Commit: #505c56a
Finding: POQ-9 (Medium Severity)