### PR TITLE
Qs fixes documentation

### DIFF
--- a/src/libraries/FinalizationLib.sol
+++ b/src/libraries/FinalizationLib.sol
@@ -125,9 +125,10 @@ library FinalizationLib {
                         $.pendingRewards[validator][proj.rewardToken] += reward;
                         $.projectEscrow[projectId][proj.rewardToken] -= actualValidatorShare;
                     }
+
+                    ReputationLib.update(validator, proj.requiredSkill, true, 0);
                 }
             }
-            ReputationLib.update(validator, proj.requiredSkill, true, 0);
         }
 
         emit ISapienCore.ValidatorSettled(projectId, index, validator, outlier);

--- a/test/findings/2026-03-09/POQ_014_NonOutlierValidatorsGainPositiveReputationOnUpheldDisputes.t.sol
+++ b/test/findings/2026-03-09/POQ_014_NonOutlierValidatorsGainPositiveReputationOnUpheldDisputes.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {BaseTest} from "test/BaseTest.sol";
+import {DisputeStatus} from "src/Types.sol";
+
+/// @title FIX VERIFIED — POQ-014: Non-Outlier Validators Gain Positive Reputation on Upheld Disputes
+/// @notice Confirms that validators who were demonstrably incorrect (their consensus was
+///         overturned by an upheld dispute) no longer receive positive reputation.
+///         This prevents the compounding feedback loop on consensus weight.
+contract POQ_014_NonOutlierValidatorsGainPositiveReputationOnUpheldDisputes is BaseTest {
+    function test_validatorsDoNotGainReputationWhenDisputeIsUpheld() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory contribIndices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = contribIndices[0];
+
+        // All three validators vote to accept (score 8000)
+        _claimAndCommit(validator1, projectId, idx, 8000, VALIDATOR_STAKE);
+        _claimAndCommit(validator2, projectId, idx, 8000, VALIDATOR_STAKE);
+        _claimAndCommit(validator3, projectId, idx, 8000, VALIDATOR_STAKE);
+        _reveal(validator1, projectId, idx, 8000);
+        _reveal(validator2, projectId, idx, 8000);
+        _reveal(validator3, projectId, idx, 8000);
+
+        // Check initial reputation
+        uint256 v1RepBefore = engine.getReputation(validator1, SKILL_ID).score;
+        uint256 v2RepBefore = engine.getReputation(validator2, SKILL_ID).score;
+        uint256 v3RepBefore = engine.getReputation(validator3, SKILL_ID).score;
+
+        // Compute consensus - contribution is accepted
+        engine.computeConsensus(projectId, idx);
+
+        // Open and uphold a dispute (proving validators were wrong)
+        vm.prank(contributor2);
+        engine.openDispute(projectId, idx, keccak256("wrong-acceptance"), "evidenceCid");
+
+        vm.prank(admin);
+        engine.resolveDispute(projectId, idx, true); // upheld = true
+
+        assertEq(
+            uint256(engine.getDispute(projectId, idx).status), uint256(DisputeStatus.Upheld), "dispute should be upheld"
+        );
+
+        // Settle validators
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+        vm.prank(validator2);
+        engine.settleValidator(projectId, idx, 0);
+        vm.prank(validator3);
+        engine.settleValidator(projectId, idx, 0);
+
+        // Check reputation after settlement
+        uint256 v1RepAfter = engine.getReputation(validator1, SKILL_ID).score;
+        uint256 v2RepAfter = engine.getReputation(validator2, SKILL_ID).score;
+        uint256 v3RepAfter = engine.getReputation(validator3, SKILL_ID).score;
+
+        // FIX: Validators should NOT gain reputation when disputes are upheld
+        assertEq(v1RepAfter, v1RepBefore, "validator1 should not gain reputation when dispute upheld");
+        assertEq(v2RepAfter, v2RepBefore, "validator2 should not gain reputation when dispute upheld");
+        assertEq(v3RepAfter, v3RepBefore, "validator3 should not gain reputation when dispute upheld");
+    }
+
+    function test_validatorsGainReputationOnlyWhenDisputeNotUpheld() public {
+        bytes32 projectId = _createAndFundProject();
+        (, uint256[] memory contribIndices) = _claimAndContribute(contributor1, projectId, 1);
+        uint256 idx = contribIndices[0];
+
+        // All three validators vote to accept (score 8000)
+        _claimAndCommit(validator1, projectId, idx, 8000, VALIDATOR_STAKE);
+        _claimAndCommit(validator2, projectId, idx, 8000, VALIDATOR_STAKE);
+        _claimAndCommit(validator3, projectId, idx, 8000, VALIDATOR_STAKE);
+        _reveal(validator1, projectId, idx, 8000);
+        _reveal(validator2, projectId, idx, 8000);
+        _reveal(validator3, projectId, idx, 8000);
+
+        // Check initial reputation
+        uint256 v1RepBefore = engine.getReputation(validator1, SKILL_ID).score;
+        uint256 v2RepBefore = engine.getReputation(validator2, SKILL_ID).score;
+        uint256 v3RepBefore = engine.getReputation(validator3, SKILL_ID).score;
+
+        // Compute consensus - contribution is accepted
+        engine.computeConsensus(projectId, idx);
+
+        // Warp past challenge period (no dispute)
+        _warpPastChallengePeriod();
+
+        // Settle validators
+        vm.prank(validator1);
+        engine.settleValidator(projectId, idx, 0);
+        vm.prank(validator2);
+        engine.settleValidator(projectId, idx, 0);
+        vm.prank(validator3);
+        engine.settleValidator(projectId, idx, 0);
+
+        // Check reputation after settlement
+        uint256 v1RepAfter = engine.getReputation(validator1, SKILL_ID).score;
+        uint256 v2RepAfter = engine.getReputation(validator2, SKILL_ID).score;
+        uint256 v3RepAfter = engine.getReputation(validator3, SKILL_ID).score;
+
+        // EXPECTED: Validators should gain reputation when no dispute is upheld
+        assertGt(v1RepAfter, v1RepBefore, "validator1 should gain reputation");
+        assertGt(v2RepAfter, v2RepBefore, "validator2 should gain reputation");
+        assertGt(v3RepAfter, v3RepBefore, "validator3 should gain reputation");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move `ReputationLib.update` call to prevent validators from gaining positive reputation when disputes are upheld, addressing Quantstamp finding POQ-14.

<div><a href="https://cursor.com/agents/bc-31a1a4ad-6ae8-43af-b937-a8e8d36a0130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31a1a4ad-6ae8-43af-b937-a8e8d36a0130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->