### PR TITLE
fix: make maxWithdraw/maxRedeem conservative for locked accounts

### DIFF
--- a/src/SapienVault.sol
+++ b/src/SapienVault.sol
@@ -167,21 +167,33 @@ contract SapienVault is
 
     /// @dev Override maxRedeem to limit withdrawals to unlocked balance
     ///      and enforce the MEV-protection time-lock (minDepositAge).
+    ///      Uses previewWithdraw (rounds up) to reserve shares for the locked
+    ///      amount so that a subsequent withdraw/redeem never undercollateralises
+    ///      the lock.
     function maxRedeem(address owner) public view override returns (uint256) {
-        if (paused() || !_hasMetDepositAge(owner)) return 0; // SEC-M-01: block redemptions when paused or time-lock active
-        uint256 avail = availableBalance(owner);
-        uint256 availShares = convertToShares(avail);
-        uint256 parentMax = super.maxRedeem(owner); // balanceOf(owner)
+        if (paused() || !_hasMetDepositAge(owner)) return 0;
+        uint256 lockedAmt = _getSapienVaultStorage().accounts[owner].lockedAmount;
+        uint256 shares = balanceOf(owner);
+        uint256 lockedShares = lockedAmt > 0 ? previewWithdraw(lockedAmt) : 0;
+        uint256 availShares = shares > lockedShares ? shares - lockedShares : 0;
+        uint256 parentMax = super.maxRedeem(owner);
         return availShares < parentMax ? availShares : parentMax;
     }
 
     /// @dev Override maxWithdraw — OZ's default does NOT delegate to maxRedeem.
-    ///      Limits withdrawals to unlocked balance and enforces MEV-protection.
+    ///      Computes available shares after reserving enough (rounded up via
+    ///      previewWithdraw) for the locked amount, then converts to assets.
+    ///      This avoids the rounding mismatch where availableBalance's floor
+    ///      asset surplus could cause withdraw() to burn more shares than safe.
     function maxWithdraw(address owner) public view override returns (uint256) {
-        if (paused() || !_hasMetDepositAge(owner)) return 0; // SEC-M-01: block withdrawals when paused or time-lock active
-        uint256 avail = availableBalance(owner);
+        if (paused() || !_hasMetDepositAge(owner)) return 0;
+        uint256 lockedAmt = _getSapienVaultStorage().accounts[owner].lockedAmount;
+        uint256 shares = balanceOf(owner);
+        uint256 lockedShares = lockedAmt > 0 ? previewWithdraw(lockedAmt) : 0;
+        uint256 availShares = shares > lockedShares ? shares - lockedShares : 0;
+        uint256 maxAssets = convertToAssets(availShares);
         uint256 parentMax = super.maxWithdraw(owner);
-        return avail < parentMax ? avail : parentMax;
+        return maxAssets < parentMax ? maxAssets : parentMax;
     }
 
     function maxDeposit(address) public view override returns (uint256) {

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -1423,11 +1423,9 @@ contract SapienVaultTest is Test {
 
     /// @dev Fuzz test: for any deposit, donation, and lock, withdrawing
     ///      maxWithdraw must preserve the locked-amount invariant.
-    function testFuzz_maxWithdraw_preservesLockInvariant(
-        uint256 depositAmt,
-        uint256 donationAmt,
-        uint256 lockAmt
-    ) public {
+    function testFuzz_maxWithdraw_preservesLockInvariant(uint256 depositAmt, uint256 donationAmt, uint256 lockAmt)
+        public
+    {
         depositAmt = bound(depositAmt, 1, 1e24);
         donationAmt = bound(donationAmt, 0, 1e24);
 
@@ -1458,20 +1456,14 @@ contract SapienVaultTest is Test {
         }
 
         uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
-        assertGe(
-            remainingAssets,
-            vault.getStakeAccount(user1).lockedAmount,
-            "Lock invariant violated"
-        );
+        assertGe(remainingAssets, vault.getStakeAccount(user1).lockedAmount, "Lock invariant violated");
     }
 
     /// @dev Fuzz test: for any deposit, donation, and lock, redeeming
     ///      maxRedeem must preserve the locked-amount invariant.
-    function testFuzz_maxRedeem_preservesLockInvariant(
-        uint256 depositAmt,
-        uint256 donationAmt,
-        uint256 lockAmt
-    ) public {
+    function testFuzz_maxRedeem_preservesLockInvariant(uint256 depositAmt, uint256 donationAmt, uint256 lockAmt)
+        public
+    {
         depositAmt = bound(depositAmt, 1, 1e24);
         donationAmt = bound(donationAmt, 0, 1e24);
 
@@ -1502,11 +1494,7 @@ contract SapienVaultTest is Test {
         }
 
         uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
-        assertGe(
-            remainingAssets,
-            vault.getStakeAccount(user1).lockedAmount,
-            "Lock invariant violated after maxRedeem"
-        );
+        assertGe(remainingAssets, vault.getStakeAccount(user1).lockedAmount, "Lock invariant violated after maxRedeem");
     }
 
     /// @dev Verifies that the fix doesn't break normal (no-lock) withdrawals.

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -1329,4 +1329,225 @@ contract SapienVaultTest is Test {
         uint256 balAfter = token.balanceOf(user1);
         assertEq(balAfter - balBefore, expectedAssets);
     }
+
+    // ── maxWithdraw rounding mismatch fix ─────────────────────────────
+
+    /// @dev Reproduces the exact scenario from the bug report:
+    ///      1. Deposit 1 wei → mints 1000 shares (decimalsOffset = 3)
+    ///      2. Donate 4 wei directly to the vault (raises exchange rate)
+    ///      3. Lock 1 wei
+    ///      4. maxWithdraw must be conservative enough that withdrawing it
+    ///         does NOT leave lockedAmount undercollateralised.
+    function test_maxWithdraw_conservativeAfterDonation() public {
+        vm.prank(user1);
+        vault.deposit(1, user1);
+
+        uint256 sharesAfterDeposit = vault.balanceOf(user1);
+        assertEq(sharesAfterDeposit, 1000, "1 wei deposit should mint 1000 shares with offset=3");
+
+        token.mint(address(this), 4);
+        token.transfer(address(vault), 4);
+
+        vm.prank(user1);
+        vault.lockStake(1);
+
+        uint256 maxW = vault.maxWithdraw(user1);
+
+        if (maxW > 0) {
+            vm.prank(user1);
+            vault.withdraw(maxW, user1, user1);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        assertGe(
+            remainingAssets,
+            vault.getStakeAccount(user1).lockedAmount,
+            "Remaining assets must cover lockedAmount after maxWithdraw withdrawal"
+        );
+    }
+
+    /// @dev After a donation that skews the exchange rate, withdrawing
+    ///      maxWithdraw should never revert and should always preserve the
+    ///      locked-amount collateral invariant.
+    function test_maxWithdraw_doesNotRevert_afterDonation() public {
+        vm.prank(user1);
+        vault.deposit(100, user1);
+
+        token.mint(address(this), 50);
+        token.transfer(address(vault), 50);
+
+        vm.prank(user1);
+        vault.lockStake(50);
+
+        uint256 maxW = vault.maxWithdraw(user1);
+
+        if (maxW > 0) {
+            vm.prank(user1);
+            vault.withdraw(maxW, user1, user1);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        assertGe(
+            remainingAssets,
+            vault.getStakeAccount(user1).lockedAmount,
+            "Lock invariant violated after withdrawing maxWithdraw"
+        );
+    }
+
+    /// @dev maxRedeem should also be conservative: redeeming maxRedeem shares
+    ///      must not undercollateralise the lock after a donation.
+    function test_maxRedeem_conservativeAfterDonation() public {
+        vm.prank(user1);
+        vault.deposit(1, user1);
+
+        token.mint(address(this), 4);
+        token.transfer(address(vault), 4);
+
+        vm.prank(user1);
+        vault.lockStake(1);
+
+        uint256 maxR = vault.maxRedeem(user1);
+
+        if (maxR > 0) {
+            vm.prank(user1);
+            vault.redeem(maxR, user1, user1);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        assertGe(
+            remainingAssets,
+            vault.getStakeAccount(user1).lockedAmount,
+            "Remaining assets must cover lockedAmount after maxRedeem redemption"
+        );
+    }
+
+    /// @dev Fuzz test: for any deposit, donation, and lock, withdrawing
+    ///      maxWithdraw must preserve the locked-amount invariant.
+    function testFuzz_maxWithdraw_preservesLockInvariant(
+        uint256 depositAmt,
+        uint256 donationAmt,
+        uint256 lockAmt
+    ) public {
+        depositAmt = bound(depositAmt, 1, 1e24);
+        donationAmt = bound(donationAmt, 0, 1e24);
+
+        token.mint(user1, depositAmt);
+        vm.prank(user1);
+        token.approve(address(vault), depositAmt);
+        vm.prank(user1);
+        vault.deposit(depositAmt, user1);
+
+        if (donationAmt > 0) {
+            token.mint(address(this), donationAmt);
+            token.transfer(address(vault), donationAmt);
+        }
+
+        uint256 userAssets = vault.convertToAssets(vault.balanceOf(user1));
+        lockAmt = bound(lockAmt, 0, userAssets);
+
+        if (lockAmt > 0) {
+            vm.prank(user1);
+            vault.lockStake(lockAmt);
+        }
+
+        uint256 maxW = vault.maxWithdraw(user1);
+
+        if (maxW > 0) {
+            vm.prank(user1);
+            vault.withdraw(maxW, user1, user1);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        assertGe(
+            remainingAssets,
+            vault.getStakeAccount(user1).lockedAmount,
+            "Lock invariant violated"
+        );
+    }
+
+    /// @dev Fuzz test: for any deposit, donation, and lock, redeeming
+    ///      maxRedeem must preserve the locked-amount invariant.
+    function testFuzz_maxRedeem_preservesLockInvariant(
+        uint256 depositAmt,
+        uint256 donationAmt,
+        uint256 lockAmt
+    ) public {
+        depositAmt = bound(depositAmt, 1, 1e24);
+        donationAmt = bound(donationAmt, 0, 1e24);
+
+        token.mint(user1, depositAmt);
+        vm.prank(user1);
+        token.approve(address(vault), depositAmt);
+        vm.prank(user1);
+        vault.deposit(depositAmt, user1);
+
+        if (donationAmt > 0) {
+            token.mint(address(this), donationAmt);
+            token.transfer(address(vault), donationAmt);
+        }
+
+        uint256 userAssets = vault.convertToAssets(vault.balanceOf(user1));
+        lockAmt = bound(lockAmt, 0, userAssets);
+
+        if (lockAmt > 0) {
+            vm.prank(user1);
+            vault.lockStake(lockAmt);
+        }
+
+        uint256 maxR = vault.maxRedeem(user1);
+
+        if (maxR > 0) {
+            vm.prank(user1);
+            vault.redeem(maxR, user1, user1);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        assertGe(
+            remainingAssets,
+            vault.getStakeAccount(user1).lockedAmount,
+            "Lock invariant violated after maxRedeem"
+        );
+    }
+
+    /// @dev Verifies that the fix doesn't break normal (no-lock) withdrawals.
+    function test_maxWithdraw_fullWithdraw_noLock() public {
+        vm.prank(user1);
+        vault.deposit(DEPOSIT_AMOUNT, user1);
+
+        token.mint(address(this), 500e18);
+        token.transfer(address(vault), 500e18);
+
+        uint256 maxW = vault.maxWithdraw(user1);
+        assertGt(maxW, 0, "maxWithdraw should be positive with no lock");
+
+        uint256 balBefore = token.balanceOf(user1);
+        vm.prank(user1);
+        vault.withdraw(maxW, user1, user1);
+        uint256 balAfter = token.balanceOf(user1);
+
+        assertEq(balAfter - balBefore, maxW, "Should withdraw exact maxWithdraw amount");
+    }
+
+    /// @dev Withdrawing exactly maxWithdraw on a partially-locked account
+    ///      should succeed and maintain the invariant.
+    function test_maxWithdraw_partialLock_postDonation() public {
+        vm.prank(user1);
+        vault.deposit(1000, user1);
+
+        token.mint(address(this), 3000);
+        token.transfer(address(vault), 3000);
+
+        vm.prank(user1);
+        vault.lockStake(500);
+
+        uint256 maxW = vault.maxWithdraw(user1);
+        assertGt(maxW, 0, "Should be able to withdraw something");
+
+        vm.prank(user1);
+        vault.withdraw(maxW, user1, user1);
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        uint256 locked = vault.getStakeAccount(user1).lockedAmount;
+        assertGe(remainingAssets, locked, "Lock invariant violated on partial lock + donation");
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the rounding mismatch in `maxWithdraw` and `maxRedeem` that could leave locked stakes undercollateralised after a legitimate withdrawal.

### Problem

`maxWithdraw` returned the floor asset surplus via `availableBalance()`, but `withdraw()` internally burns shares rounded **up** (via `previewWithdraw`). In a high exchange-rate scenario (e.g. after donations raise `totalAssets` relative to `totalSupply`), withdrawing the full `maxWithdraw` amount could burn more shares than intended, leaving the account with fewer shares than needed to back `lockedAmount`.

**Reproduction (from issue):**
1. Deposit 1 wei → mints 1000 shares (due to `_decimalsOffset() = 3`)
2. Donate 4 wei of underlying asset directly to the vault (raises exchange rate)
3. Lock 1 wei via `lockStake(1)`
4. `maxWithdraw(user)` → returns 2 (floor of `availableBalance`)
5. Withdraw 2 → burns 667 shares (rounded up), leaving 333 shares worth 0 assets while `lockedAmount` is still 1

### Fix

Both `maxWithdraw` and `maxRedeem` now compute the shares needed to cover `lockedAmount` using `previewWithdraw` (which rounds up), then derive available shares from the remainder:

```solidity
uint256 lockedShares = lockedAmt > 0 ? previewWithdraw(lockedAmt) : 0;
uint256 availShares = shares > lockedShares ? shares - lockedShares : 0;
```

This ensures the share reservation is always at least as large as what `withdraw()` would actually burn, preserving the invariant that locked assets remain fully collateralised.

### Changes

- **`src/SapienVault.sol`**: Updated `maxWithdraw` and `maxRedeem` to use `previewWithdraw`-based share reservation instead of `availableBalance`
- **`test/SapienVault.t.sol`**: Added 8 new tests:
  - `test_maxWithdraw_conservativeAfterDonation` — exact bug report scenario
  - `test_maxWithdraw_doesNotRevert_afterDonation` — broader donation scenario
  - `test_maxRedeem_conservativeAfterDonation` — same fix applied to redeem path
  - `testFuzz_maxWithdraw_preservesLockInvariant` — fuzz: arbitrary deposit/donation/lock
  - `testFuzz_maxRedeem_preservesLockInvariant` — fuzz: same for redeem
  - `test_maxWithdraw_fullWithdraw_noLock` — regression: no-lock path still works
  - `test_maxWithdraw_partialLock_postDonation` — partial lock with large donation
  - All existing tests continue to pass (93 total)

### Test Results

All 93 tests pass. Lint clean (only pre-existing informational `block.timestamp` warning).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1022d14f-a7ec-4b36-897b-1a263591404e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1022d14f-a7ec-4b36-897b-1a263591404e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

