### PR TITLE
fix: use previewWithdraw (rounds up) in transfer guard to prevent undercollateralisation

### DIFF
--- a/src/SapienVault.sol
+++ b/src/SapienVault.sol
@@ -212,6 +212,8 @@ contract SapienVault is
     ///      Sets the receiver's deposit timestamp on receipt to prevent bypassing
     ///      minDepositAge via share transfers (note: this allows inbound griefing).
     ///      Mints (from == 0) and burns (to == 0) are unrestricted.
+    ///      Uses previewWithdraw (rounds up) to reserve shares for the locked
+    ///      amount so that transfers never undercollateralise the lock.
     function _update(address from, address to, uint256 value) internal override {
         if (from != address(0) && to != address(0)) {
             _requireNotPaused();
@@ -222,7 +224,7 @@ contract SapienVault is
             SapienVaultStorage storage $ = _getSapienVaultStorage();
             StakeAccount storage acct = $.accounts[from];
             uint256 totalLocked = acct.lockedAmount;
-            uint256 lockedShares = convertToShares(totalLocked);
+            uint256 lockedShares = totalLocked > 0 ? previewWithdraw(totalLocked) : 0;
             if (balanceOf(from) < value + lockedShares) revert TransferExceedsUnlockedShares();
 
             // Set deposit timestamp for any recipient to prevent bypassing

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -1584,9 +1584,7 @@ contract SapienVaultTest is Test {
         vault.lockStake(lockAmt);
 
         uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
-        uint256 maxTransferable = userShares > lockedSharesNeeded
-            ? userShares - lockedSharesNeeded
-            : 0;
+        uint256 maxTransferable = userShares > lockedSharesNeeded ? userShares - lockedSharesNeeded : 0;
 
         if (maxTransferable < userShares) {
             vm.expectRevert(ISapienVault.TransferExceedsUnlockedShares.selector);
@@ -1621,9 +1619,7 @@ contract SapienVaultTest is Test {
         vault.lockStake(lockAmt);
 
         uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
-        uint256 maxTransferable = userShares > lockedSharesNeeded
-            ? userShares - lockedSharesNeeded
-            : 0;
+        uint256 maxTransferable = userShares > lockedSharesNeeded ? userShares - lockedSharesNeeded : 0;
 
         if (maxTransferable > 0) {
             vm.prank(user1);
@@ -1637,11 +1633,9 @@ contract SapienVaultTest is Test {
 
     /// @dev Fuzz test: after a donation that raises the exchange rate, the transfer
     ///      guard must never allow transferring shares that undercollateralise the lock.
-    function testFuzz_transferGuard_roundUp_invariant(
-        uint256 depositAmt,
-        uint256 donationAmt,
-        uint256 lockFraction
-    ) public {
+    function testFuzz_transferGuard_roundUp_invariant(uint256 depositAmt, uint256 donationAmt, uint256 lockFraction)
+        public
+    {
         depositAmt = bound(depositAmt, 1e6, 1e24);
         donationAmt = bound(donationAmt, 1, 1e24);
         lockFraction = bound(lockFraction, 1, 1e18);
@@ -1662,9 +1656,7 @@ contract SapienVaultTest is Test {
         vault.lockStake(lockAmt);
 
         uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
-        uint256 maxTransferable = userShares > lockedSharesNeeded
-            ? userShares - lockedSharesNeeded
-            : 0;
+        uint256 maxTransferable = userShares > lockedSharesNeeded ? userShares - lockedSharesNeeded : 0;
 
         if (maxTransferable > 0) {
             vm.prank(user1);

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -1538,4 +1538,158 @@ contract SapienVaultTest is Test {
         uint256 locked = vault.getStakeAccount(user1).lockedAmount;
         assertGe(remainingAssets, locked, "Lock invariant violated on partial lock + donation");
     }
+
+    // ── Transfer guard rounding-up fix tests ────────────────────────
+
+    /// @dev Reproduce the undercollateralisation bug: with a high exchange rate,
+    ///      convertToShares(lockedAmount) rounds down to 0, letting the user
+    ///      transfer all shares despite having a non-zero lockedAmount.
+    ///      After the fix (previewWithdraw rounds up), this transfer must revert.
+    function test_transferGuard_preventsUndercollateralisation_highExchangeRate() public {
+        vm.prank(user1);
+        vault.deposit(1e18, user1);
+
+        uint256 sharesBefore = vault.balanceOf(user1);
+        assertGt(sharesBefore, 0, "User should have shares after deposit");
+
+        token.mint(address(this), 1000e18);
+        token.transfer(address(vault), 1000e18);
+
+        vm.prank(user1);
+        vault.lockStake(1);
+
+        uint256 lockedShares = vault.previewWithdraw(1);
+        assertGt(lockedShares, 0, "previewWithdraw should round up to at least 1 share");
+
+        vm.expectRevert(ISapienVault.TransferExceedsUnlockedShares.selector);
+        vm.prank(user1);
+        vault.transfer(user2, sharesBefore);
+    }
+
+    /// @dev Even with small locked amounts and high exchange rate, the user
+    ///      cannot transfer away shares that would leave lockedAmount undercollateralised.
+    function test_transferGuard_roundUpReservation_smallLock() public {
+        vm.prank(user1);
+        vault.deposit(10e18, user1);
+
+        token.mint(address(this), 10_000e18);
+        token.transfer(address(vault), 10_000e18);
+
+        uint256 userShares = vault.balanceOf(user1);
+        uint256 userAssets = vault.convertToAssets(userShares);
+        uint256 lockAmt = userAssets / 100;
+        assertGt(lockAmt, 0, "lockAmt must be > 0");
+
+        vm.prank(user1);
+        vault.lockStake(lockAmt);
+
+        uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
+        uint256 maxTransferable = userShares > lockedSharesNeeded
+            ? userShares - lockedSharesNeeded
+            : 0;
+
+        if (maxTransferable < userShares) {
+            vm.expectRevert(ISapienVault.TransferExceedsUnlockedShares.selector);
+            vm.prank(user1);
+            vault.transfer(user2, userShares);
+        }
+
+        if (maxTransferable > 0) {
+            vm.prank(user1);
+            vault.transfer(user2, maxTransferable);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        uint256 locked = vault.getStakeAccount(user1).lockedAmount;
+        assertGe(remainingAssets, locked, "Lock invariant violated after transfer");
+    }
+
+    /// @dev Verify that transferring exactly the unlocked portion succeeds
+    ///      and the lock invariant holds, even after a large donation.
+    function test_transferGuard_allowsMaxUnlocked_postDonation() public {
+        vm.prank(user1);
+        vault.deposit(100e18, user1);
+
+        token.mint(address(this), 5000e18);
+        token.transfer(address(vault), 5000e18);
+
+        uint256 userShares = vault.balanceOf(user1);
+        uint256 userAssets = vault.convertToAssets(userShares);
+        uint256 lockAmt = userAssets / 2;
+
+        vm.prank(user1);
+        vault.lockStake(lockAmt);
+
+        uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
+        uint256 maxTransferable = userShares > lockedSharesNeeded
+            ? userShares - lockedSharesNeeded
+            : 0;
+
+        if (maxTransferable > 0) {
+            vm.prank(user1);
+            vault.transfer(user2, maxTransferable);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        uint256 locked = vault.getStakeAccount(user1).lockedAmount;
+        assertGe(remainingAssets, locked, "Lock invariant violated after max transfer");
+    }
+
+    /// @dev Fuzz test: after a donation that raises the exchange rate, the transfer
+    ///      guard must never allow transferring shares that undercollateralise the lock.
+    function testFuzz_transferGuard_roundUp_invariant(
+        uint256 depositAmt,
+        uint256 donationAmt,
+        uint256 lockFraction
+    ) public {
+        depositAmt = bound(depositAmt, 1e6, 1e24);
+        donationAmt = bound(donationAmt, 1, 1e24);
+        lockFraction = bound(lockFraction, 1, 1e18);
+
+        token.mint(user1, depositAmt);
+        vm.prank(user1);
+        vault.deposit(depositAmt, user1);
+
+        token.mint(address(this), donationAmt);
+        token.transfer(address(vault), donationAmt);
+
+        uint256 userShares = vault.balanceOf(user1);
+        uint256 userAssets = vault.convertToAssets(userShares);
+        uint256 lockAmt = (userAssets * lockFraction) / 1e18;
+        if (lockAmt == 0 || lockAmt > userAssets) return;
+
+        vm.prank(user1);
+        vault.lockStake(lockAmt);
+
+        uint256 lockedSharesNeeded = vault.previewWithdraw(lockAmt);
+        uint256 maxTransferable = userShares > lockedSharesNeeded
+            ? userShares - lockedSharesNeeded
+            : 0;
+
+        if (maxTransferable > 0) {
+            vm.prank(user1);
+            vault.transfer(user2, maxTransferable);
+        }
+
+        uint256 remainingAssets = vault.convertToAssets(vault.balanceOf(user1));
+        uint256 locked = vault.getStakeAccount(user1).lockedAmount;
+        assertGe(remainingAssets, locked, "Fuzz: lock invariant violated after transfer");
+    }
+
+    /// @dev Transferring all shares when nothing is locked should still work fine.
+    function test_transferGuard_noLock_fullTransfer_postDonation() public {
+        vm.prank(user1);
+        vault.deposit(100e18, user1);
+
+        token.mint(address(this), 5000e18);
+        token.transfer(address(vault), 5000e18);
+
+        uint256 userShares = vault.balanceOf(user1);
+
+        vm.prank(user1);
+        vault.transfer(user2, userShares);
+
+        assertEq(vault.balanceOf(user1), 0);
+        assertEq(vault.balanceOf(user2), userShares);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the rounding bug in the `_update` transfer guard where `convertToShares(totalLocked)` rounds **down**, allowing share transfers that leave `lockedAmount` undercollateralised when the exchange rate is high.

## Problem

In `_update`, the contract computed:
```solidity
uint256 lockedShares = convertToShares(totalLocked);
```

`convertToShares` uses `Math.Rounding.Down` (per ERC-4626 spec). When the exchange rate is elevated (e.g. after asset donations to the vault), a non-zero `lockedAmount` could convert to **0 shares**, letting the holder transfer away all shares while their lock remained non-zero — completely bypassing the stake lock mechanism.

## Fix

Changed the transfer guard to use `previewWithdraw` (which rounds **up**), consistent with how `maxRedeem` and `maxWithdraw` already handle locked share reservation:

```solidity
uint256 lockedShares = totalLocked > 0 ? previewWithdraw(totalLocked) : 0;
```

This ensures the guard always reserves at least enough shares to cover the locked amount, even at extreme exchange rates.

## Tests Added

5 new tests covering the fix:

| Test | Description |
|------|-------------|
| `test_transferGuard_preventsUndercollateralisation_highExchangeRate` | Reproduces the exact bug scenario: deposit, donate to raise rate, lock small amount, attempt full transfer — now correctly reverts |
| `test_transferGuard_roundUpReservation_smallLock` | Verifies round-up reservation with small locks at high exchange rates |
| `test_transferGuard_allowsMaxUnlocked_postDonation` | Confirms transferring exactly the unlocked portion still succeeds post-donation |
| `testFuzz_transferGuard_roundUp_invariant` | Fuzz test: lock invariant holds after transfers across random deposit/donation/lock combinations |
| `test_transferGuard_noLock_fullTransfer_postDonation` | No-lock transfers remain unaffected by the change |

All 98 tests pass (89 unit + 2 mock + 7 invariant), including the existing test suite with zero regressions.

## Location

- `src/SapienVault.sol` — `_update` function (line ~217)
- `test/SapienVault.t.sol` — new tests at end of file
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b82baf2-2665-45aa-98a1-acce65992912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b82baf2-2665-45aa-98a1-acce65992912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

