### PR TITLE
Chore/security checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ whitepaper.toc
 
 lcov.info
 venv
+
+.venv-security

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "solhint:recommended"
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ ERC-4626 vault for SAPIEN token staking with typed lock categories. Holds user f
 
 Full vault design, roles, ERC-4626 behavior, locking/slashing, and integration notes: **[docs/SapienVault.md](docs/SapienVault.md)**.
 
+## Roles & trust assumptions
+
+The vault concentrates several privileged actions in two roles. Operators
+holding either role are explicitly trusted; deploy-time policy SHOULD assign
+both to a multisig and route admin actions through a timelock.
+
+| Role | Holder (recommended) | Privileged actions |
+|------|---------------------|--------------------|
+| `DEFAULT_ADMIN_ROLE` | Multisig behind a `TimelockController` | `setMinDepositAge`, `pause` / `unpause`, `rescueETH`, `_authorizeUpgrade` (UUPS), `grantRole` / `revokeRole` |
+| `ENGINE_ROLE` | Multisig or attestation-validated key | `unlockStake`, `slashStake` (burns user shares — irreversible) |
+
+Trust assumptions:
+
+- The admin can deploy a malicious implementation via UUPS at any time. There
+  is no on-chain timelock at the contract level; users rely on whatever
+  governance wraps `DEFAULT_ADMIN_ROLE`.
+- The engine can slash any user up to their `lockedAmount`. Slashes are
+  pause-gated (SEC-M-03): pressing pause halts both `unlockStake` and
+  `slashStake`. To stop a compromised engine permanently, admin must
+  `revokeRole(ENGINE_ROLE, …)`.
+- Deposits made on behalf of a third party (caller != receiver) do NOT reset
+  the receiver's MEV deposit-age timer (SEC-M-01). Wallet-to-wallet share
+  transfers DO reset the recipient's timer; this is a known griefing trade-off
+  preferred over the alternative of allowing instant lock bypass via sybil
+  share transfers.
+- Asset is assumed to be a non-fee, non-rebasing ERC-20 (USDC on Base in
+  production deployments). Slashing math assumes a stable asset/share map.
+
 ## Build & test
 
 ```bash

--- a/src/SapienVault.sol
+++ b/src/SapienVault.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import {
     ERC4626Upgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {
     AccessControlUpgradeable
 } from "lib/openzeppelin-contracts-upgradeable/contracts/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/PausableUpgradeable.sol";
+import {
+    ReentrancyGuardUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
 import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ISapienVault} from "src/interfaces/ISapienVault.sol";
 import {SapienVaultStorage, StakeAccount} from "src/Types.sol";
@@ -22,19 +24,23 @@ contract SapienVault is
     ERC4626Upgradeable,
     AccessControlUpgradeable,
     PausableUpgradeable,
+    ReentrancyGuardUpgradeable,
     UUPSUpgradeable,
     ISapienVault
 {
-    using SafeERC20 for IERC20;
-
     // ── Roles ──────────────────────────────────────────────────────────
+
+    /// @notice Role permitted to call `unlockStake` and `slashStake`.
     bytes32 public constant ENGINE_ROLE = keccak256("ENGINE_ROLE");
 
+    /// @notice Upper bound (in seconds) on the configurable `minDepositAge` MEV guard.
     uint256 public constant MAX_MIN_DEPOSIT_AGE = 7 days;
 
-    function _getSapienVaultStorage() private pure returns (SapienVaultStorage storage $) {
+    /// @notice Returns the ERC-7201 namespaced storage struct for SapienVault.
+    /// @return s Reference to the namespaced `SapienVaultStorage` struct.
+    function _getSapienVaultStorage() private pure returns (SapienVaultStorage storage s) {
         assembly {
-            $.slot := 0x4d6e6410717d1c28e2e2dce6e8ac53def1f84cd7244221b7a072c02c51460000
+            s.slot := 0x4d6e6410717d1c28e2e2dce6e8ac53def1f84cd7244221b7a072c02c51460000
         }
     }
 
@@ -66,7 +72,10 @@ contract SapienVault is
         __ERC20_init("Sapien PoQ Vault", "vSAPIEN");
         __AccessControl_init();
         __Pausable_init();
-        _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+        __ReentrancyGuard_init();
+        // SEC-L-04: assert the role grant succeeded; on a fresh initializer this
+        // is always true, but we no longer silently discard the return value.
+        assert(_grantRole(DEFAULT_ADMIN_ROLE, admin_));
     }
 
     // ── ERC-4626 inflation attack mitigation ───────────────────────────
@@ -99,9 +108,18 @@ contract SapienVault is
         }
     }
 
-    /// @dev Tracks the timestamp of any inbound deposit, resetting the MEV time-lock.
+    /// @dev Tracks the timestamp of a self-deposit, resetting the MEV time-lock.
+    ///      Deposits made on behalf of another address (caller != receiver) do
+    ///      NOT update the receiver's timestamp — otherwise an attacker could
+    ///      grief any user by dust-depositing to their address every
+    ///      `minDepositAge` seconds and freezing their lock/transfer/withdraw
+    ///      flows (SEC-M-01). Third-party-funded shares still arrive at the
+    ///      receiver and remain subject to whatever timer the receiver already
+    ///      has from their own prior deposits or inbound transfers.
     function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal override {
-        _getSapienVaultStorage().lastDepositTimestamp[receiver] = block.timestamp;
+        if (caller == receiver) {
+            _getSapienVaultStorage().lastDepositTimestamp[receiver] = block.timestamp;
+        }
         super._deposit(caller, receiver, assets, shares);
     }
 
@@ -123,7 +141,7 @@ contract SapienVault is
     }
 
     /// @inheritdoc ISapienVault
-    function unlockStake(address user, uint256 amount) external onlyRole(ENGINE_ROLE) {
+    function unlockStake(address user, uint256 amount) external onlyRole(ENGINE_ROLE) whenNotPaused {
         if (amount == 0) revert ZeroAmount();
         StakeAccount storage acct = _getSapienVaultStorage().accounts[user];
         if (acct.lockedAmount < amount) revert InsufficientLockedAmount(amount, acct.lockedAmount);
@@ -133,7 +151,7 @@ contract SapienVault is
     }
 
     /// @inheritdoc ISapienVault
-    function slashStake(address user, uint256 amount) external onlyRole(ENGINE_ROLE) {
+    function slashStake(address user, uint256 amount) external onlyRole(ENGINE_ROLE) whenNotPaused {
         if (amount == 0) revert ZeroAmount();
         StakeAccount storage acct = _getSapienVaultStorage().accounts[user];
         if (acct.lockedAmount < amount) revert InsufficientLockedAmount(amount, acct.lockedAmount);
@@ -165,11 +183,15 @@ contract SapienVault is
 
     // ── Withdrawal guard ───────────────────────────────────────────────
 
-    /// @dev Override maxRedeem to limit withdrawals to unlocked balance
-    ///      and enforce the MEV-protection time-lock (minDepositAge).
-    ///      Uses previewWithdraw (rounds up) to reserve shares for the locked
-    ///      amount so that a subsequent withdraw/redeem never undercollateralises
-    ///      the lock.
+    /// @notice Maximum shares that `owner` can redeem at the current block.
+    /// @dev Overrides ERC4626Upgradeable to limit redemptions to unlocked balance
+    ///      and enforce the MEV-protection time-lock (minDepositAge). Returns 0
+    ///      while paused or while the owner is still inside their deposit-age
+    ///      window. Uses previewWithdraw (rounds up) to reserve shares for the
+    ///      locked amount so that a subsequent withdraw/redeem never
+    ///      undercollateralises the lock.
+    /// @param owner Address whose redeemable shares are being queried.
+    /// @return Maximum number of shares redeemable by `owner`.
     function maxRedeem(address owner) public view override returns (uint256) {
         if (paused() || !_hasMetDepositAge(owner)) return 0;
         uint256 lockedAmt = _getSapienVaultStorage().accounts[owner].lockedAmount;
@@ -180,11 +202,16 @@ contract SapienVault is
         return availShares < parentMax ? availShares : parentMax;
     }
 
-    /// @dev Override maxWithdraw — OZ's default does NOT delegate to maxRedeem.
-    ///      Computes available shares after reserving enough (rounded up via
-    ///      previewWithdraw) for the locked amount, then converts to assets.
-    ///      This avoids the rounding mismatch where availableBalance's floor
-    ///      asset surplus could cause withdraw() to burn more shares than safe.
+    /// @notice Maximum assets that `owner` can withdraw at the current block.
+    /// @dev Overrides ERC4626Upgradeable; OZ's default does NOT delegate to
+    ///      maxRedeem. Computes available shares after reserving enough (rounded
+    ///      up via previewWithdraw) for the locked amount, then converts to
+    ///      assets. This avoids the rounding mismatch where availableBalance's
+    ///      floor asset surplus could cause withdraw() to burn more shares than
+    ///      safe. Returns 0 while paused or before the deposit-age timer has
+    ///      elapsed.
+    /// @param owner Address whose withdrawable assets are being queried.
+    /// @return Maximum amount of assets withdrawable by `owner`.
     function maxWithdraw(address owner) public view override returns (uint256) {
         if (paused() || !_hasMetDepositAge(owner)) return 0;
         uint256 lockedAmt = _getSapienVaultStorage().accounts[owner].lockedAmount;
@@ -196,11 +223,23 @@ contract SapienVault is
         return maxAssets < parentMax ? maxAssets : parentMax;
     }
 
-    function maxDeposit(address) public view override returns (uint256) {
+    /// @notice Maximum assets that may be deposited into the vault.
+    /// @dev Returns 0 while paused; otherwise unbounded (subject to caller's
+    ///      asset balance and approval). The receiver argument is unused.
+    /// @param receiver Account credited with the deposited shares (unused).
+    /// @return Maximum depositable asset amount.
+    function maxDeposit(address receiver) public view override returns (uint256) {
+        receiver;
         return paused() ? 0 : type(uint256).max;
     }
 
-    function maxMint(address) public view override returns (uint256) {
+    /// @notice Maximum shares that may be minted from the vault.
+    /// @dev Returns 0 while paused; otherwise unbounded (subject to caller's
+    ///      asset balance and approval). The receiver argument is unused.
+    /// @param receiver Account credited with the minted shares (unused).
+    /// @return Maximum mintable share amount.
+    function maxMint(address receiver) public view override returns (uint256) {
+        receiver;
         return paused() ? 0 : type(uint256).max;
     }
 
@@ -282,13 +321,17 @@ contract SapienVault is
     ///      OZ's `upgradeToAndCall(address,bytes)` is payable, so an admin upgrade
     ///      with non-zero `msg.value` could leave ETH stuck on the proxy. This
     ///      function is the recovery path. Admin-only, full balance, low-level call.
-    function rescueETH(address payable to) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    ///      `nonReentrant` is defense-in-depth — there are no post-call state
+    ///      writes, but the recipient is admin-chosen and unconstrained
+    ///      (SEC-L-03). The event is emitted before the external call to keep
+    ///      strict checks-effects-interactions ordering.
+    function rescueETH(address payable to) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         if (to == address(0)) revert ZeroAddress();
         uint256 amount = address(this).balance;
         if (amount == 0) revert ZeroAmount();
+        emit EthRescued(to, amount);
         (bool ok,) = to.call{value: amount}("");
         if (!ok) revert EthTransferFailed();
-        emit EthRescued(to, amount);
     }
 
     // ── UUPS ───────────────────────────────────────────────────────────

--- a/src/SapienVault.sol
+++ b/src/SapienVault.sol
@@ -275,6 +275,22 @@ contract SapienVault is
         _unpause();
     }
 
+    // ── ETH rescue ─────────────────────────────────────────────────────
+
+    /// @inheritdoc ISapienVault
+    /// @dev Resolves the "locked-ETH" detector: although the vault's asset is ERC-20,
+    ///      OZ's `upgradeToAndCall(address,bytes)` is payable, so an admin upgrade
+    ///      with non-zero `msg.value` could leave ETH stuck on the proxy. This
+    ///      function is the recovery path. Admin-only, full balance, low-level call.
+    function rescueETH(address payable to) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (to == address(0)) revert ZeroAddress();
+        uint256 amount = address(this).balance;
+        if (amount == 0) revert ZeroAmount();
+        (bool ok,) = to.call{value: amount}("");
+        if (!ok) revert EthTransferFailed();
+        emit EthRescued(to, amount);
+    }
+
     // ── UUPS ───────────────────────────────────────────────────────────
 
     function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 struct StakeAccount {
     uint256 lockedAmount;

--- a/src/interfaces/ISapienVault.sol
+++ b/src/interfaces/ISapienVault.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import {StakeAccount} from "src/Types.sol";
 
 /// @title ISapienVault
+/// @author Sapien
 /// @notice Interface for the SapienVault — the staking and escrow layer.
 /// @dev Manages a single locked stake bucket per user.
 ///      lockStake is called by the owner; unlockStake and slashStake require ENGINE_ROLE.
@@ -20,11 +21,30 @@ interface ISapienVault {
     error EthTransferFailed();
 
     // ── Events ─────────────────────────────────────────────────────────
-    event StakeLocked(address indexed user, uint256 amount);
-    event StakeUnlocked(address indexed user, uint256 amount);
-    event StakeSlashed(address indexed user, uint256 amount);
-    event MinDepositAgeUpdated(uint256 newAge);
-    event EthRescued(address indexed to, uint256 amount);
+
+    /// @notice Emitted when a user moves stake from available to locked.
+    /// @param user Address whose stake was locked.
+    /// @param amount Asset-denominated amount that became locked.
+    event StakeLocked(address indexed user, uint256 indexed amount);
+
+    /// @notice Emitted when the engine returns locked stake to available balance.
+    /// @param user Address whose stake was unlocked.
+    /// @param amount Asset-denominated amount that was unlocked.
+    event StakeUnlocked(address indexed user, uint256 indexed amount);
+
+    /// @notice Emitted when the engine slashes locked stake (shares are burned).
+    /// @param user Address whose stake was slashed.
+    /// @param amount Asset-denominated amount that was slashed.
+    event StakeSlashed(address indexed user, uint256 indexed amount);
+
+    /// @notice Emitted when the admin updates the minimum deposit-age timer.
+    /// @param newAge New minimum deposit age, in seconds.
+    event MinDepositAgeUpdated(uint256 indexed newAge);
+
+    /// @notice Emitted when admin rescues stuck ETH from the proxy.
+    /// @param to Recipient of the rescued ETH.
+    /// @param amount Wei amount transferred.
+    event EthRescued(address indexed to, uint256 indexed amount);
 
     // ── Stake Operations ───────────────────────────────────────────────
 

--- a/src/interfaces/ISapienVault.sol
+++ b/src/interfaces/ISapienVault.sol
@@ -17,12 +17,14 @@ interface ISapienVault {
     error ZeroAmount();
     error ZeroAddress();
     error ZeroShareSlash();
+    error EthTransferFailed();
 
     // ── Events ─────────────────────────────────────────────────────────
     event StakeLocked(address indexed user, uint256 amount);
     event StakeUnlocked(address indexed user, uint256 amount);
     event StakeSlashed(address indexed user, uint256 amount);
     event MinDepositAgeUpdated(uint256 newAge);
+    event EthRescued(address indexed to, uint256 amount);
 
     // ── Stake Operations ───────────────────────────────────────────────
 
@@ -86,4 +88,11 @@ interface ISapienVault {
 
     /// @notice Unpause vault operations.
     function unpause() external;
+
+    /// @notice Rescue ETH that was sent to the vault (e.g. via the inherited
+    ///         payable `upgradeToAndCall`) and forward it to `to`.
+    /// @dev Admin-only. The vault's asset is ERC-20; it never holds ETH by design.
+    ///      Provided so any accidentally-stuck ETH is recoverable.
+    /// @param to Recipient of the rescued ETH.
+    function rescueETH(address payable to) external;
 }

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -361,9 +361,54 @@ contract SapienVaultTest is Test {
         assertEq(acct.lockedAmount, 400e18);
     }
 
+    /// @dev SEC-M-03: pause must halt engine-driven mutations. Admin remains
+    ///      able to neutralise a misbehaving engine by `revokeRole` while
+    ///      paused; this test only asserts the pause modifier itself.
+    function test_unlockStake_revertsWhenPaused() public {
+        vm.prank(user1);
+        vault.deposit(DEPOSIT_AMOUNT, user1);
+        vm.prank(user1);
+        vault.lockStake(400e18);
+
+        vm.prank(admin);
+        vault.pause();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.prank(engine);
+        vault.unlockStake(user1, 100e18);
+    }
+
+    /// @dev SEC-M-03: slashStake also gated by pause for symmetry with
+    ///      unlockStake. Unblocks once admin unpauses.
+    function test_slashStake_revertsWhenPaused() public {
+        vm.prank(user1);
+        vault.deposit(DEPOSIT_AMOUNT, user1);
+        vm.prank(user1);
+        vault.lockStake(400e18);
+
+        vm.prank(admin);
+        vault.pause();
+
+        vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vm.prank(engine);
+        vault.slashStake(user1, 100e18);
+
+        vm.prank(admin);
+        vault.unpause();
+
+        vm.prank(engine);
+        vault.slashStake(user1, 100e18);
+
+        assertEq(vault.getStakeAccount(user1).lockedAmount, 300e18);
+    }
+
     // ── Deposit-timestamp time-lock bypass resistance ───────────────
 
-    function test_depositOnBehalf_resetsTimestamp() public {
+    /// @dev SEC-M-01 regression: a deposit made by an attacker on behalf of
+    ///      `user1` (caller != receiver) must NOT reset the receiver's
+    ///      deposit-age timer; otherwise dust deposits become a DoS griefing
+    ///      vector against any staker.
+    function test_depositOnBehalf_doesNotResetTimestamp() public {
         vm.prank(admin);
         vault.setMinDepositAge(1 days);
 
@@ -378,9 +423,11 @@ contract SapienVaultTest is Test {
         vm.prank(user2);
         vault.deposit(1, user1);
 
-        vm.expectRevert(abi.encodeWithSelector(ISapienVault.DepositTooRecent.selector, 1 days, 0));
         vm.prank(user1);
         vault.lockStake(400e18);
+
+        StakeAccount memory acct = vault.getStakeAccount(user1);
+        assertEq(acct.lockedAmount, 400e18, "user1 should still be able to lockStake after on-behalf-of dust deposit");
     }
 
     function test_transfer_resetsTimestampOfExistingStaker() public {
@@ -402,7 +449,13 @@ contract SapienVaultTest is Test {
         vault.lockStake(400e18);
     }
 
-    function test_bypass_thirdPartyDeposit_ZeroTimestamp() public {
+    /// @dev SEC-M-01: when a third party funds `user1`'s vault position and
+    ///      `user1` has never self-deposited, the receiver's stored timestamp
+    ///      stays at 0 (the "no prior deposit" sentinel). user1 is therefore
+    ///      free to lock the granted shares immediately — the third party
+    ///      cannot weaponise the timer against them, and the time-lock is only
+    ///      meaningful for shares the user themselves brought in.
+    function test_thirdPartyDeposit_doesNotSetTimestamp() public {
         vm.prank(admin);
         vault.setMinDepositAge(1 days);
 
@@ -413,9 +466,11 @@ contract SapienVaultTest is Test {
         vm.prank(user2);
         vault.deposit(DEPOSIT_AMOUNT, user1);
 
-        vm.expectRevert(abi.encodeWithSelector(ISapienVault.DepositTooRecent.selector, 1 days, 0));
         vm.prank(user1);
         vault.lockStake(DEPOSIT_AMOUNT);
+
+        StakeAccount memory acct = vault.getStakeAccount(user1);
+        assertEq(acct.lockedAmount, DEPOSIT_AMOUNT);
     }
 
     function test_bypass_warmSybilTransfer() public {
@@ -1025,7 +1080,7 @@ contract SapienVaultTest is Test {
         vm.prank(user1);
         vault.deposit(DEPOSIT_AMOUNT, user1);
 
-        vm.expectEmit(true, false, false, true, address(vault));
+        vm.expectEmit(true, true, false, true, address(vault));
         emit ISapienVault.StakeLocked(user1, 400e18);
 
         vm.prank(user1);
@@ -1038,7 +1093,7 @@ contract SapienVaultTest is Test {
         vm.prank(user1);
         vault.lockStake(400e18);
 
-        vm.expectEmit(true, false, false, true, address(vault));
+        vm.expectEmit(true, true, false, true, address(vault));
         emit ISapienVault.StakeUnlocked(user1, 150e18);
 
         vm.prank(engine);
@@ -1051,7 +1106,7 @@ contract SapienVaultTest is Test {
         vm.prank(user1);
         vault.lockStake(400e18);
 
-        vm.expectEmit(true, false, false, true, address(vault));
+        vm.expectEmit(true, true, false, true, address(vault));
         emit ISapienVault.StakeSlashed(user1, 100e18);
 
         vm.prank(engine);
@@ -1059,7 +1114,7 @@ contract SapienVaultTest is Test {
     }
 
     function test_setMinDepositAge_emitsMinDepositAgeUpdated() public {
-        vm.expectEmit(false, false, false, true, address(vault));
+        vm.expectEmit(true, false, false, true, address(vault));
         emit ISapienVault.MinDepositAgeUpdated(1 days);
 
         vm.prank(admin);
@@ -1832,7 +1887,7 @@ contract SapienVaultTest is Test {
         assertEq(address(vault).balance, 1 ether);
         assertEq(recipient.balance, 0);
 
-        vm.expectEmit(true, false, false, true, address(vault));
+        vm.expectEmit(true, true, false, true, address(vault));
         emit ISapienVault.EthRescued(recipient, 1 ether);
 
         vm.prank(admin);

--- a/test/SapienVault.t.sol
+++ b/test/SapienVault.t.sol
@@ -1820,4 +1820,81 @@ contract SapienVaultTest is Test {
         assertEq(vault.balanceOf(user1), 0);
         assertEq(vault.balanceOf(user2), userShares);
     }
+
+    // ── ETH rescue (Aderyn H-1) ────────────────────────────────────────
+
+    /// @dev Admin can recover ETH that lands on the proxy (e.g. via the inherited
+    ///      payable `upgradeToAndCall`). Validates the H-1 mitigation.
+    function test_rescueETH_adminCanRecover() public {
+        address payable recipient = payable(makeAddr("recipient"));
+        vm.deal(address(vault), 1 ether);
+
+        assertEq(address(vault).balance, 1 ether);
+        assertEq(recipient.balance, 0);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit ISapienVault.EthRescued(recipient, 1 ether);
+
+        vm.prank(admin);
+        vault.rescueETH(recipient);
+
+        assertEq(address(vault).balance, 0);
+        assertEq(recipient.balance, 1 ether);
+    }
+
+    function test_rescueETH_revertsForNonAdmin() public {
+        vm.deal(address(vault), 1 ether);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, ADMIN_ROLE)
+        );
+        vm.prank(user1);
+        vault.rescueETH(payable(user1));
+    }
+
+    function test_rescueETH_revertsOnZeroAddress() public {
+        vm.deal(address(vault), 1 ether);
+
+        vm.expectRevert(ISapienVault.ZeroAddress.selector);
+        vm.prank(admin);
+        vault.rescueETH(payable(address(0)));
+    }
+
+    function test_rescueETH_revertsWhenNoBalance() public {
+        assertEq(address(vault).balance, 0);
+
+        vm.expectRevert(ISapienVault.ZeroAmount.selector);
+        vm.prank(admin);
+        vault.rescueETH(payable(makeAddr("recipient")));
+    }
+
+    function test_rescueETH_revertsWhenRecipientRejects() public {
+        EthRejector rejector = new EthRejector();
+        vm.deal(address(vault), 1 ether);
+
+        vm.expectRevert(ISapienVault.EthTransferFailed.selector);
+        vm.prank(admin);
+        vault.rescueETH(payable(address(rejector)));
+
+        assertEq(address(vault).balance, 1 ether, "ETH must remain on revert");
+    }
+
+    function testFuzz_rescueETH_anyBalance(uint96 amount) public {
+        vm.assume(amount > 0);
+        address payable recipient = payable(makeAddr("recipient"));
+        vm.deal(address(vault), amount);
+
+        vm.prank(admin);
+        vault.rescueETH(recipient);
+
+        assertEq(address(vault).balance, 0);
+        assertEq(recipient.balance, amount);
+    }
+}
+
+/// @dev Receiver that always rejects ETH; used to exercise the rescue failure path.
+contract EthRejector {
+    receive() external payable {
+        revert("nope");
+    }
 }

--- a/test/SapienVaultHandler.t.sol
+++ b/test/SapienVaultHandler.t.sol
@@ -65,7 +65,13 @@ contract SapienVaultHandler is Test {
         vm.prank(caller);
         vault.deposit(amount, receiver);
 
-        actorLastDepositTs[receiver] = block.timestamp;
+        // SEC-M-01: when caller != receiver the contract no longer resets the
+        // receiver's deposit-age timer, so the handler's mirror must mirror
+        // that. When caller == receiver this code path is equivalent to a
+        // self-deposit and we must update the timer.
+        if (caller == receiver) {
+            actorLastDepositTs[receiver] = block.timestamp;
+        }
     }
 
     function mintShares(uint256 actorSeed, uint256 shares) public {


### PR DESCRIPTION
## Summary
Address the actionable findings from the agent-driven security review of `SapienVault`. Scope is limited to fixes the team accepted; M-02, M-04, L-01, and L-02 were explicitly deferred.
## Changes
- **M-01 — deposit-on-behalf MEV-timer griefing.** `_deposit` now resets `lastDepositTimestamp[receiver]` only when `caller == receiver`. Third-party deposits still mint shares to the receiver but can no longer be used to DoS their `lockStake` / `transfer` / `withdraw` flows.
- **M-03 — pause as engine kill-switch.** Added `whenNotPaused` to `unlockStake` and `slashStake`. Admin retains the ability to neutralise a misbehaving engine permanently via `revokeRole(ENGINE_ROLE, …)`.
- **L-03 — `rescueETH` hardening.** Inherited `ReentrancyGuardUpgradeable`, marked `rescueETH` `nonReentrant`, and moved the `EthRescued` emit before the low-level call (strict CEI). Clears Slither's `reentrancy-events` finding.
- **L-04 — assert role grant.** `_grantRole(DEFAULT_ADMIN_ROLE, admin_)` is now wrapped in `assert(...)` instead of silently dropping the bool.
- **Hygiene.** Removed the unused `using SafeERC20 for IERC20;` directive, added full `@notice`/`@param`/`@return` natspec to the four `max*` overrides, indexed `amount` on `StakeLocked`/`StakeUnlocked`/`StakeSlashed`/`EthRescued` and `newAge` on `MinDepositAgeUpdated`, and documented a "Roles & trust assumptions" section in the README.
## Test plan
- [x] `forge build` clean
- [x] `forge test` — **111/111 pass** (added `test_depositOnBehalf_doesNotResetTimestamp`, `test_thirdPartyDeposit_doesNotSetTimestamp`, `test_unlockStake_revertsWhenPaused`, `test_slashStake_revertsWhenPaused`; inverted the two pre-existing tests that encoded the M-01 vulnerability)
- [x] Invariant suite — 7/7 invariants hold across 1024 runs × 50 depth (unlockStake/slashStake now correctly revert during paused phases)
- [x] `forge coverage` on `src/SapienVault.sol` — 100% lines / 100% funcs / 95.83% branches
- [x] Slither: 10 → 9 findings (reentrancy-events cleared; remaining are admin-gated or design-accepted)
- [x] Solhint on `src/`: 33 → 5 warnings (remaining are style-only)
## Out of scope (deferred per design decision)
- M-02 share-transfer timer-reset griefing (acknowledged trade-off)
- M-04 timelock + two-step admin
- L-01 `_decimalsOffset` bump
- L-02 asset metadata sanity check