### PR TITLE
feat: wire Sepolia collateral loop (lock, unlock, slash)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,18 @@ upgrade-sepolia-verify :; VERIFY_ONLY=true forge script script/UpgradeVault.s.so
 #   make test-fork-mainnet    # requires BASE_MAINNET_RPC_URL
 #   make test-fork-sepolia    # requires BASE_SEPOLIA_RPC_URL (or FORK_RPC_URL)
 test-fork-sepolia :; forge test --match-path test/fork/SepoliaUpgradeFork.t.sol -vvv
+test-fork-sepolia-loop :; forge test --match-path test/fork/SepoliaCollateralLoop.t.sol -vvv
 test-fork-mainnet :; forge test --match-path test/fork/UpgradeFork.t.sol -vvv
+
+# ── Sepolia ENGINE_ROLE grant ──────────────────────────────────────────
+# Staging engine signer only. Script refuses the mainnet vault.
+# Requires: SEPOLIA_ENGINE, BASE_SEPOLIA_RPC_URL. See script/README.md.
+grant-engine-sepolia-calldata :; forge script script/GrantEngineRole.s.sol:GrantEngineRole \
+	--rpc-url $${BASE_SEPOLIA_RPC_URL}
+grant-engine-sepolia-execute :; EXECUTE=true forge script script/GrantEngineRole.s.sol:GrantEngineRole \
+	--rpc-url $${BASE_SEPOLIA_RPC_URL} \
+	--account $${DEPLOYER} \
+	--broadcast
+grant-engine-sepolia-verify :; VERIFY_ONLY=true forge script script/GrantEngineRole.s.sol:GrantEngineRole \
+	--rpc-url $${BASE_SEPOLIA_RPC_URL}
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ ERC-4626 vault for SAPIEN token staking with typed lock categories. Holds user f
 
 Full vault design, roles, ERC-4626 behavior, locking/slashing, and integration notes: **[docs/SapienVault.md](docs/SapienVault.md)**.
 
+Sepolia lock → review → unlock or slash (Basescan vs `report.stake`): **[docs/SepoliaCollateralLoop.md](docs/SepoliaCollateralLoop.md)**.
+
 Sapien token MiCA whitepaper: **[docs/Sapien_Token_White_Paper_MiCA_v1.pdf](docs/Sapien_Token_White_Paper_MiCA_v1.pdf)**.
 
 ## Roles & trust assumptions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # Documentation
 
 - **[SapienVault](SapienVault.md)** — architecture, roles, ERC-4626 behavior, locking/slashing, `minDepositAge`, pause, upgrades, errors, and integration notes.
+- **[Sepolia collateral loop](SepoliaCollateralLoop.md)** — lock → review → unlock or slash on Base Sepolia; `report.stake` field mapping and Basescan observer checklist. Mainnet vault/rewards are out of scope.
 
 For build, test, deploy commands, and chain addresses, see the root [README](../README.md).

--- a/docs/SapienVault.md
+++ b/docs/SapienVault.md
@@ -229,6 +229,7 @@ This makes **engine liveness — not just engine honesty — part of the trust m
 
 ## Further reading
 
+- [Sepolia collateral loop](SepoliaCollateralLoop.md) — lock → review → unlock or slash on the live Sepolia vault; `report.stake` mapping for observers. The vault still does not compute consensus.
 - [OpenZeppelin ERC-4626](https://docs.openzeppelin.com/contracts/erc4626)
 - [Foundry book](https://book.getfoundry.sh/) — build, test, and deploy in this repo
 

--- a/docs/SepoliaCollateralLoop.md
+++ b/docs/SepoliaCollateralLoop.md
@@ -1,0 +1,121 @@
+# Sepolia collateral loop
+
+On-chain half of lock → review → unlock or slash on **Base Sepolia**. The vault
+does not score, quorum, or compute consensus. The off-chain PoQ engine (paired
+ticket: poq-monorepo #1760) decides the outcome and writes `report.stake`. This
+document is the observer checklist: Basescan Sepolia versus the amounts the
+engine will put in that report.
+
+Mainnet vault `0x60Bf63729f688287a450299962b36Cef0aFfaa42` and the 20% rewards
+program are out of scope. Do not grant `ENGINE_ROLE` there with the scripts in
+this repo (`script/GrantEngineRole.s.sol` refuses that address).
+
+---
+
+## Addresses (Base Sepolia, chain id 84532)
+
+| Piece | Address |
+|-------|---------|
+| Vault (UUPS proxy, V2) | [`0x58E72Fa7fb92B100f2c652377465EEEe2642544C`](https://sepolia.basescan.org/address/0x58E72Fa7fb92B100f2c652377465EEEe2642544C) |
+| SAPIEN | [`0x7F54613f339d15424E9AdE87967BAE40b23Fa7F6`](https://sepolia.basescan.org/address/0x7F54613f339d15424E9AdE87967BAE40b23Fa7F6) |
+| Admin Safe (`DEFAULT_ADMIN_ROLE`) | `0x5602be03ecFfBB85D12b7404d4B38AF58277E4cC` |
+
+`ENGINE_ROLE` is granted to the **staging engine signer** via
+`script/GrantEngineRole.s.sol` (Safe calldata). Set `SEPOLIA_ENGINE` to that
+signer. After the Safe executes, `VERIFY_ONLY=true` confirms the role.
+
+```bash
+export BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+export SEPOLIA_ENGINE=0x...   # staging engine signer
+
+make grant-engine-sepolia-calldata   # print grantRole calldata for the Safe
+# Safe UI: target = vault proxy, value 0, paste calldata, sign, execute
+make grant-engine-sepolia-verify     # read-only hasRole check
+```
+
+---
+
+## Loop
+
+`minDepositAge` on the live Sepolia vault is `DEFAULT_MIN_DEPOSIT_AGE` (1 day).
+A test vault may set it to `0`, in which case step 2 is a no-op.
+
+1. **Deposit.** Validator `approve`s Sepolia SAPIEN and `deposit`s. Fresh shares
+   are pending until they clear `minDepositAge`.
+2. **Wait.** `skip(minDepositAge)` in tests; wall-clock on the live network.
+3. **Lock.** Validator calls `lockStake(amount)` themselves (not the engine).
+   Emits `StakeLocked(user, amount)`. `getStakeAccount(user).lockedAmount`
+   increases by `amount`.
+4. **Review** happens off-chain. The vault is not called and does not compute
+   consensus. Record `lockedAmount` at this moment — that is
+   `stake.stake_at_risk_wei`.
+5. **Outcome** (engine, `ENGINE_ROLE` only):
+   - **Accepted** → `unlockStake(user, amount)` → `StakeUnlocked`.
+   - **Forced** → `slashStake(user, amount)` → `StakeSlashed` + `SharesSlashed`
+     (shares burned; SAP-2 dilution-compensated).
+
+Pause blocks lock, unlock, and slash. Admin can `revokeRole(ENGINE_ROLE, …)`
+to neutralize a compromised signer; that does not unlock already-locked stake.
+
+---
+
+## `report.stake` (engine writes these; vault does not)
+
+| Field | Accepted (`unlockStake`) | Forced (`slashStake`) | On-chain source |
+|-------|--------------------------|-----------------------|-----------------|
+| `stake.slashed_wei` | `"0"` | decimal string of the slashed **asset** amount | `0`, or `StakeSlashed.amount` (log topic `[2]`; the `amount` argument). This is intended net asset damage, not `convertToAssets(sharesBurned)`. |
+| `stake.stake_at_risk_wei` | locked amount at review time | locked amount at review time | `getStakeAccount(user).lockedAmount` **before** unlock/slash |
+
+`SharesSlashed.shares` is the burn quantity (larger than a naive
+`convertToShares(amount)` — SAP-2). Indexers track it for share supply; the
+report field `slashed_wei` stays in **assets**.
+
+Event amounts are **indexed** (`topics[2]`), not in the log `data` payload.
+See [SapienVault.md — Events](SapienVault.md#events).
+
+---
+
+## Observer checklist (Basescan Sepolia)
+
+Open the vault on
+[Basescan Sepolia](https://sepolia.basescan.org/address/0x58E72Fa7fb92B100f2c652377465EEEe2642544C#events)
+and match:
+
+| Step | Event | Read |
+|------|-------|------|
+| Lock | `StakeLocked` | `amount` == assets the validator locked |
+| Unlock | `StakeUnlocked` | `amount` unlocked; `getStakeAccount.lockedAmount` dropped; report `slashed_wei = "0"`, `stake_at_risk_wei` = locked amount at review |
+| Slash | `StakeSlashed` + `SharesSlashed` | `StakeSlashed.amount` == report `slashed_wei`; `SharesSlashed.shares > 0`; HTML report links the slash tx |
+
+HTML report slash link (engine emits this; tests pin the helper):
+
+```
+https://sepolia.basescan.org/tx/<slashTxHash>
+```
+
+---
+
+## Tests
+
+| Suite | When it runs | What it proves |
+|-------|--------------|----------------|
+| `test/CollateralLoop.t.sol` | every `forge test` | deposit → wait default `minDepositAge` → lock; unlock → `slashed_wei = 0`; slash burns shares and sets `slashed_wei` to the asset amount; Basescan URL helper |
+| `test/SapienVaultNoConsensus.t.sol` | every `forge test` | no `computeConsensus` / `score` / `quorum` functions on `SapienVault` or `ISapienVault`; mainnet deployment pins unchanged |
+| `test/fork/SepoliaCollateralLoop.t.sol` | `make test-fork-sepolia-loop` (needs `BASE_SEPOLIA_RPC_URL`) | same loop against the live V2 proxy; fork-local `grantRole` so the loop runs before the Safe grant lands; if `SEPOLIA_ENGINE` is set, asserts that address already holds the role |
+
+```bash
+forge test --match-path test/CollateralLoop.t.sol
+forge test --match-path test/SapienVaultNoConsensus.t.sol
+make test-fork-sepolia-loop    # BASE_SEPOLIA_RPC_URL required
+```
+
+CI does not set a Sepolia RPC, so the fork suite skips there (same pattern as
+`SepoliaUpgradeFork`).
+
+---
+
+## Out of scope
+
+- Engine `report.stake` emission and HTML report rendering (poq-monorepo #1760).
+- Attestation registry (issue #168).
+- EAS, vault-app UI, mainnet vault / rewards.

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,10 @@ solc_version = "0.8.36"
 # fork the chain does not support risks emitting unsupported opcodes and makes
 # the bytecode unreproducible for Etherscan verification.
 evm_version = "cancun"
-fs_permissions = [{ access = "read-write", path = "./deployments" }]
+fs_permissions = [
+    { access = "read-write", path = "./deployments" },
+    { access = "read", path = "./src" },
+]
 
 # Invariant test configuration (full load — used for local runs; PR CI uses
 # the reduced [profile.ci.invariant] below).

--- a/script/GrantEngineRole.s.sol
+++ b/script/GrantEngineRole.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.36;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SapienVault} from "src/SapienVault.sol";
+
+/// @title GrantEngineRole
+/// @notice Print (or execute) `grantRole(ENGINE_ROLE, engine)` for the **Sepolia**
+///         vault. The mainnet vault is refused — this script will not target it.
+///
+/// @dev Three modes, matching `UpgradeVault`:
+///
+///        1. Calldata (default) — print Safe calldata. Nothing is broadcast
+///           to the proxy. Submit from the `DEFAULT_ADMIN_ROLE` Safe with
+///           target = the Sepolia vault proxy.
+///        2. Execute (`EXECUTE=true`) — broadcast `grantRole` from the
+///           configured account (must hold `DEFAULT_ADMIN_ROLE`).
+///        3. Verify (`VERIFY_ONLY=true`) — read-only. Asserts `engine` already
+///           holds `ENGINE_ROLE` on the Sepolia vault.
+///
+///      Env:
+///        SEPOLIA_ENGINE  - staging engine signer to grant (required)
+///        VAULT_PROXY     - optional; defaults to the live Sepolia UUPS proxy
+///        EXECUTE         - optional ("true"): broadcast the grant
+///        VERIFY_ONLY     - optional ("true"): read-only role check
+///
+///      Run: see `script/README.md` / `make grant-engine-sepolia-calldata`.
+contract GrantEngineRole is Script {
+    /// @dev Live Base Sepolia proxy (`deployments/base-sepolia.json`).
+    address internal constant SEPOLIA_VAULT = 0x58E72Fa7fb92B100f2c652377465EEEe2642544C;
+
+    /// @dev Live Base mainnet proxy. Untouchable — this script reverts if aimed here.
+    address internal constant MAINNET_VAULT = 0x60Bf63729f688287a450299962b36Cef0aFfaa42;
+
+    /// @notice Print, execute, or verify the Sepolia `ENGINE_ROLE` grant.
+    function run() external {
+        address proxy = vm.envOr("VAULT_PROXY", SEPOLIA_VAULT);
+        address engine = vm.envAddress("SEPOLIA_ENGINE");
+
+        _requireSepolia(proxy);
+
+        SapienVault vault = SapienVault(proxy);
+
+        if (vm.envOr("VERIFY_ONLY", false)) {
+            _verify(vault, engine);
+            return;
+        }
+
+        bytes memory grantCalldata = abi.encodeCall(vault.grantRole, (vault.ENGINE_ROLE(), engine));
+
+        bool execute = vm.envOr("EXECUTE", false);
+        if (execute) {
+            vm.startBroadcast();
+            vault.grantRole(vault.ENGINE_ROLE(), engine);
+            vm.stopBroadcast();
+            _verify(vault, engine);
+            return;
+        }
+
+        console.log("Network:           Base Sepolia (84532)");
+        console.log("Vault proxy:       ", proxy);
+        console.log("Engine signer:     ", engine);
+        console.log("Submit this grantRole calldata from the admin Safe (target = proxy):");
+        console.logBytes(grantCalldata);
+    }
+
+    /// @dev Refuse the mainnet vault and any proxy that is not the Sepolia UUPS.
+    function _requireSepolia(address proxy) internal pure {
+        require(proxy != MAINNET_VAULT, "GrantEngineRole: mainnet vault is untouchable");
+        require(proxy == SEPOLIA_VAULT, "GrantEngineRole: VAULT_PROXY is not the Sepolia vault");
+    }
+
+    /// @dev Reverts if `engine` does not hold `ENGINE_ROLE` on `vault`.
+    function _verify(SapienVault vault, address engine) internal view {
+        require(address(vault) == SEPOLIA_VAULT, "verify: not the Sepolia vault");
+        require(vault.hasRole(vault.ENGINE_ROLE(), engine), "verify: engine missing ENGINE_ROLE");
+        console.log("ENGINE_ROLE verified on Sepolia vault:");
+        console.log("  vault:  ", address(vault));
+        console.log("  engine: ", engine);
+    }
+}

--- a/script/README.md
+++ b/script/README.md
@@ -10,6 +10,7 @@ implementation behind it. Only `DEFAULT_ADMIN_ROLE` can authorize an upgrade
 | `DeployBase.s.sol` | **Canonical** first-time deploy of impl + proxy (`initialize`); env-driven (`SAPIEN_TOKEN`, `ADMIN`) |
 | `DeployBaseSepolia.s.sol` | Base Sepolia deploy (hardcoded testnet token + dev Safe) |
 | `UpgradeVault.s.sol` | Upgrade a live proxy to a new implementation (`upgradeToAndCall` + `initializeV2`), with post-upgrade verification |
+| `GrantEngineRole.s.sol` | **Sepolia only** — print / execute / verify `grantRole(ENGINE_ROLE, SEPOLIA_ENGINE)`. Refuses the mainnet vault. |
 | `archive/DeployBaseMainnet.s.sol` | **Archived, reverts on run** — original mainnet deploy with hardcoded admin; the vault is already live (SEC-3) |
 
 Live addresses are in the repo [README](../README.md). Design and upgrade
@@ -160,6 +161,28 @@ export ETHERSCAN_API_KEY=...
 forge verify-contract <impl> src/SapienVault.sol:SapienVault \
   --chain-id 84532 --watch
 ```
+
+---
+
+## Grant `ENGINE_ROLE` on Sepolia
+
+The staging engine signer needs `ENGINE_ROLE` on the Sepolia vault to call
+`unlockStake` / `slashStake`. The admin is a Safe, so the default path prints
+calldata. The script **reverts** if `VAULT_PROXY` is the mainnet vault
+(`0x60Bf63729f688287a450299962b36Cef0aFfaa42`) or anything other than the
+Sepolia UUPS (`0x58E72Fa7fb92B100f2c652377465EEEe2642544C`).
+
+```bash
+export BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+export SEPOLIA_ENGINE=0x...    # staging engine signer
+
+make grant-engine-sepolia-calldata   # print grantRole calldata
+# Safe: target = 0x58E72Fa7…, value 0, paste calldata
+make grant-engine-sepolia-verify     # read-only hasRole check
+```
+
+Loop, `report.stake` fields, and Basescan observer notes:
+[docs/SepoliaCollateralLoop.md](../docs/SepoliaCollateralLoop.md).
 
 ---
 

--- a/test/CollateralLoop.t.sol
+++ b/test/CollateralLoop.t.sol
@@ -33,8 +33,9 @@ contract CollateralLoopTest is Test {
             )
         );
 
+        bytes32 engineRole = vault.ENGINE_ROLE();
         vm.prank(admin);
-        vault.grantRole(vault.ENGINE_ROLE(), engine);
+        vault.grantRole(engineRole, engine);
 
         token.mint(validator, DEPOSIT);
         vm.prank(validator);

--- a/test/CollateralLoop.t.sol
+++ b/test/CollateralLoop.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.36;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IAccessControl} from "lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {SapienVault} from "src/SapienVault.sol";
+import {ISapienVault} from "src/interfaces/ISapienVault.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {StakeAccount} from "src/Types.sol";
+import {CollateralReport} from "test/CollateralReport.sol";
+
+/// @title Local collateral loop: deposit → age → lock → unlock or slash
+/// @notice Mirrors issue #167 against an in-process vault (CI always runs this).
+///         The live-Sepolia / fork counterpart is `test/fork/SepoliaCollateralLoop.t.sol`.
+contract CollateralLoopTest is Test {
+    uint256 internal constant DEPOSIT = 1000e18;
+    uint256 internal constant LOCK = 400e18;
+
+    SapienVault internal vault;
+    MockERC20 internal token;
+    address internal admin = makeAddr("admin");
+    address internal engine = makeAddr("engine");
+    address internal validator = makeAddr("validator");
+
+    function setUp() public {
+        token = new MockERC20("Sapien Token", "SAPIEN");
+        SapienVault impl = new SapienVault();
+        vault = SapienVault(
+            address(
+                new ERC1967Proxy(address(impl), abi.encodeCall(SapienVault.initialize, (IERC20(address(token)), admin)))
+            )
+        );
+
+        vm.prank(admin);
+        vault.grantRole(vault.ENGINE_ROLE(), engine);
+
+        token.mint(validator, DEPOSIT);
+        vm.prank(validator);
+        token.approve(address(vault), DEPOSIT);
+    }
+
+    /// @notice AC1: deposit, wait `minDepositAge` (seeded default), then `lockStake`.
+    ///         Engine holds `ENGINE_ROLE`.
+    function test_depositWaitLock_engineHasRole() public {
+        assertTrue(vault.hasRole(vault.ENGINE_ROLE(), engine), "engine missing ENGINE_ROLE");
+        assertEq(vault.minDepositAge(), vault.DEFAULT_MIN_DEPOSIT_AGE());
+
+        vm.prank(validator);
+        uint256 shares = vault.deposit(DEPOSIT, validator);
+        assertGt(shares, 0, "deposit minted no shares");
+        assertEq(vault.maturedShares(validator), 0, "fresh deposit already mature");
+
+        vm.prank(validator);
+        vm.expectRevert(abi.encodeWithSelector(ISapienVault.InsufficientAvailableBalance.selector, LOCK, 0));
+        vault.lockStake(LOCK);
+
+        skip(vault.minDepositAge());
+
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+
+        StakeAccount memory acct = vault.getStakeAccount(validator);
+        assertEq(acct.lockedAmount, LOCK, "lockedAmount != lock");
+        assertEq(vault.availableBalance(validator), DEPOSIT - LOCK);
+    }
+
+    /// @notice AC2 happy path: accepted review → `unlockStake` → report.stake.
+    function test_acceptedReview_unlock_reportStake() public {
+        _depositMatureAndLock();
+
+        uint256 lockedAtReview = vault.getStakeAccount(validator).lockedAmount;
+        CollateralReport.Stake memory stake = CollateralReport.accepted(lockedAtReview);
+
+        vm.expectEmit(true, true, false, true, address(vault));
+        emit ISapienVault.StakeUnlocked(validator, LOCK);
+
+        vm.prank(engine);
+        vault.unlockStake(validator, LOCK);
+
+        assertEq(stake.slashedWei, 0, "stake.slashed_wei must be 0");
+        assertEq(stake.stakeAtRiskWei, LOCK, "stake.stake_at_risk_wei != locked at review");
+        assertEq(vault.getStakeAccount(validator).lockedAmount, 0, "lock not cleared");
+        assertEq(vault.availableBalance(validator), DEPOSIT);
+    }
+
+    /// @notice AC3 forced path: `slashStake` burns shares; report.stake + Basescan URL.
+    function test_forcedReview_slash_reportStakeAndBasescanUrl() public {
+        _depositMatureAndLock();
+
+        uint256 lockedAtReview = vault.getStakeAccount(validator).lockedAmount;
+        uint256 sharesBefore = vault.balanceOf(validator);
+
+        vm.recordLogs();
+        vm.prank(engine);
+        vault.slashStake(validator, LOCK);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool sawSlash;
+        bool sawShares;
+        for (uint256 i; i < logs.length; ++i) {
+            if (logs[i].emitter != address(vault)) continue;
+            if (logs[i].topics[0] == ISapienVault.StakeSlashed.selector) {
+                assertEq(uint256(logs[i].topics[2]), LOCK, "StakeSlashed.amount != burned assets");
+                sawSlash = true;
+            }
+            if (logs[i].topics[0] == ISapienVault.SharesSlashed.selector) {
+                assertGt(uint256(logs[i].topics[2]), 0, "SharesSlashed.shares == 0");
+                sawShares = true;
+            }
+        }
+        assertTrue(sawSlash, "missing StakeSlashed");
+        assertTrue(sawShares, "missing SharesSlashed");
+
+        uint256 sharesAfter = vault.balanceOf(validator);
+        assertLt(sharesAfter, sharesBefore, "slash did not burn shares");
+
+        CollateralReport.Stake memory stake = CollateralReport.slashed(LOCK, lockedAtReview);
+        assertEq(stake.slashedWei, LOCK, "stake.slashed_wei != burned asset amount");
+        assertEq(stake.stakeAtRiskWei, lockedAtReview, "stake.stake_at_risk_wei != locked at review");
+        assertEq(vault.getStakeAccount(validator).lockedAmount, 0, "lock not reduced");
+
+        bytes32 slashTx = keccak256("sepolia-slash-example");
+        assertEq(
+            CollateralReport.sepoliaTxUrl(slashTx),
+            string.concat("https://sepolia.basescan.org/tx/", vm.toString(slashTx))
+        );
+    }
+
+    /// @notice Unlock / slash remain `ENGINE_ROLE`-gated (owner cannot self-unlock).
+    function test_unlockAndSlash_onlyEngine() public {
+        _depositMatureAndLock();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, validator, vault.ENGINE_ROLE()
+            )
+        );
+        vm.prank(validator);
+        vault.unlockStake(validator, LOCK);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, validator, vault.ENGINE_ROLE()
+            )
+        );
+        vm.prank(validator);
+        vault.slashStake(validator, LOCK);
+    }
+
+    function _depositMatureAndLock() internal {
+        vm.prank(validator);
+        vault.deposit(DEPOSIT, validator);
+        skip(vault.minDepositAge());
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+    }
+}

--- a/test/CollateralReport.sol
+++ b/test/CollateralReport.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.36;
+
+import {Vm} from "forge-std/Vm.sol";
+
+/// @notice Off-chain `report.stake` fields the engine (poq-monorepo #1760) will
+///         write after a Sepolia review. The vault never computes these; tests
+///         and observers use them to check Basescan against the signed report.
+library CollateralReport {
+    /// @dev Foundry VM address (same as `Test.vm`).
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    struct Stake {
+        /// @dev `stake.slashed_wei` — `"0"` on unlock; the `slashStake` asset
+        ///      amount (also `StakeSlashed.amount`) on slash.
+        uint256 slashedWei;
+        /// @dev `stake.stake_at_risk_wei` — `getStakeAccount(user).lockedAmount`
+        ///      at review time, before unlock or slash.
+        uint256 stakeAtRiskWei;
+    }
+
+    /// @notice Accepted review: engine calls `unlockStake`; nothing is burned.
+    function accepted(uint256 lockedAtReview) internal pure returns (Stake memory) {
+        return Stake({slashedWei: 0, stakeAtRiskWei: lockedAtReview});
+    }
+
+    /// @notice Forced review: engine calls `slashStake`; `slashedWei` is the
+    ///         intended net asset damage (the `amount` argument / `StakeSlashed`).
+    function slashed(uint256 burnedAssets, uint256 lockedAtReview) internal pure returns (Stake memory) {
+        return Stake({slashedWei: burnedAssets, stakeAtRiskWei: lockedAtReview});
+    }
+
+    /// @notice Basescan Sepolia URL an HTML report can use for the slash tx.
+    function sepoliaTxUrl(bytes32 txHash) internal pure returns (string memory) {
+        return string.concat("https://sepolia.basescan.org/tx/", VM.toString(txHash));
+    }
+}

--- a/test/SapienVaultNoConsensus.t.sol
+++ b/test/SapienVaultNoConsensus.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.36;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SapienVault} from "src/SapienVault.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+
+/// @title Vault does not compute consensus
+/// @notice Issue #167: no scoring / quorum / consensus entrypoints on
+///         `SapienVault` or `ISapienVault`. Adding one fails this suite.
+contract SapienVaultNoConsensusTest is Test {
+    SapienVault internal vault;
+
+    function setUp() public {
+        MockERC20 token = new MockERC20("Sapien Token", "SAPIEN");
+        SapienVault impl = new SapienVault();
+        vault = SapienVault(
+            address(
+                new ERC1967Proxy(
+                    address(impl), abi.encodeCall(SapienVault.initialize, (IERC20(address(token)), address(this)))
+                )
+            )
+        );
+    }
+
+    /// @notice Source scan: `function <forbidden>` must not appear on the vault
+    ///         or its interface. Comments that mention "consensus" are allowed
+    ///         (the interface already describes slashing as an engine decision).
+    function test_sourceHasNoConsensusEntrypoints() public view {
+        _assertNoForbiddenFunctions(vm.readFile("src/SapienVault.sol"));
+        _assertNoForbiddenFunctions(vm.readFile("src/interfaces/ISapienVault.sol"));
+    }
+
+    /// @notice Selector probe: unrecognized scoring / quorum functions revert
+    ///         (no fallback on the implementation; the proxy delegates that revert).
+    function test_selectorsHaveNoConsensusEntrypoints() public {
+        bytes4[10] memory forbidden = [
+            bytes4(keccak256("computeConsensus()")),
+            bytes4(keccak256("computeConsensus(uint256)")),
+            bytes4(keccak256("computeQuorum()")),
+            bytes4(keccak256("quorum()")),
+            bytes4(keccak256("score(address)")),
+            bytes4(keccak256("getScore(address)")),
+            bytes4(keccak256("setScore(address,uint256)")),
+            bytes4(keccak256("submitScore(address,uint256)")),
+            bytes4(keccak256("getQuorum()")),
+            bytes4(keccak256("setQuorum(uint256)"))
+        ];
+        for (uint256 i; i < forbidden.length; ++i) {
+            (bool ok,) = address(vault).staticcall(abi.encodePacked(forbidden[i]));
+            assertFalse(ok, "vault answered a consensus/scoring/quorum selector");
+        }
+    }
+
+    /// @notice Mainnet deployment pins stay exactly the live rewards vault.
+    function test_mainnetDeploymentPinsUnchanged() public view {
+        string memory json = vm.readFile("deployments/base-mainnet.json");
+        assertEq(vm.parseJsonAddress(json, ".vaultAddress"), 0x60Bf63729f688287a450299962b36Cef0aFfaa42);
+        assertEq(vm.parseJsonAddress(json, ".sapienAddress"), 0xC729777d0470F30612B1564Fd96E8Dd26f5814E3);
+        assertEq(vm.parseJsonAddress(json, ".usdcAddress"), 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913);
+        assertEq(vm.parseJsonUint(json, ".chainId"), 8453);
+    }
+
+    /// @notice Sepolia wiring targets the live V2 UUPS, not a new proxy.
+    function test_sepoliaDeploymentPinsLiveV2() public view {
+        string memory json = vm.readFile("deployments/base-sepolia.json");
+        assertEq(vm.parseJsonAddress(json, ".vaultAddress"), 0x58E72Fa7fb92B100f2c652377465EEEe2642544C);
+        assertEq(vm.parseJsonAddress(json, ".sapienAddress"), 0x7F54613f339d15424E9AdE87967BAE40b23Fa7F6);
+        assertEq(vm.parseJsonUint(json, ".chainId"), 84532);
+    }
+
+    function _assertNoForbiddenFunctions(string memory src) internal pure {
+        string[10] memory needles = [
+            "function computeConsensus",
+            "function computeQuorum",
+            "function quorum(",
+            "function quorum (",
+            "function score(",
+            "function score (",
+            "function getScore",
+            "function setScore",
+            "function submitScore",
+            "function getQuorum"
+        ];
+        for (uint256 i; i < needles.length; ++i) {
+            require(!_contains(src, needles[i]), "forbidden consensus/scoring/quorum function");
+        }
+    }
+
+    function _contains(string memory hay, string memory needle) internal pure returns (bool) {
+        bytes memory h = bytes(hay);
+        bytes memory n = bytes(needle);
+        if (n.length == 0 || n.length > h.length) return false;
+        uint256 end = h.length - n.length;
+        for (uint256 i; i <= end; ++i) {
+            bool found = true;
+            for (uint256 j; j < n.length; ++j) {
+                if (h[i + j] != n[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) return true;
+        }
+        return false;
+    }
+}

--- a/test/fork/SepoliaCollateralLoop.t.sol
+++ b/test/fork/SepoliaCollateralLoop.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.36;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IAccessControl} from "lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {SapienVault} from "src/SapienVault.sol";
+import {ISapienVault} from "src/interfaces/ISapienVault.sol";
+import {StakeAccount} from "src/Types.sol";
+import {CollateralReport} from "test/CollateralReport.sol";
+
+/// @title Base-Sepolia fork of the lock → review → unlock/slash loop
+/// @notice Issue #167 against the live V2 UUPS. Skips when no Sepolia RPC is set.
+///
+/// @dev Environment:
+///        BASE_SEPOLIA_RPC_URL / FORK_RPC_URL — required; suite skips when unset.
+///        FORK_BLOCK                          — optional; pin for determinism.
+///        SEPOLIA_ENGINE                      — optional; if set, assert this
+///                                              address already holds ENGINE_ROLE
+///                                              on the live vault.
+///
+///      Run: BASE_SEPOLIA_RPC_URL=... forge test --match-path test/fork/SepoliaCollateralLoop.t.sol -vvv
+contract SepoliaCollateralLoopTest is Test {
+    address internal constant PROXY = 0x58E72Fa7fb92B100f2c652377465EEEe2642544C;
+    address internal constant SAPIEN = 0x7F54613f339d15424E9AdE87967BAE40b23Fa7F6;
+    address internal constant MAINNET_VAULT = 0x60Bf63729f688287a450299962b36Cef0aFfaa42;
+    address internal constant KNOWN_ADMIN = 0x5602be03ecFfBB85D12b7404d4B38AF58277E4cC;
+
+    uint256 internal constant DEPOSIT = 1_000e18;
+    uint256 internal constant LOCK = 400e18;
+
+    SapienVault internal vault = SapienVault(PROXY);
+    address internal admin;
+    address internal engine;
+    bool internal forkEnabled;
+
+    function setUp() public {
+        string memory rpc = vm.envOr("FORK_RPC_URL", string(""));
+        if (bytes(rpc).length == 0) {
+            rpc = vm.envOr("BASE_SEPOLIA_RPC_URL", string(""));
+        }
+        if (bytes(rpc).length == 0) return;
+
+        uint256 forkBlock = vm.envOr("FORK_BLOCK", uint256(0));
+        if (forkBlock > 0) {
+            vm.createSelectFork(rpc, forkBlock);
+        } else {
+            vm.createSelectFork(rpc);
+        }
+        forkEnabled = true;
+
+        admin = KNOWN_ADMIN;
+        engine = makeAddr("sepoliaEngine");
+
+        // Fork-local grant so unlock/slash can run even before the Safe
+        // submits `GrantEngineRole` calldata on the live vault.
+        vm.prank(admin);
+        vault.grantRole(vault.ENGINE_ROLE(), engine);
+    }
+
+    modifier onlyFork() {
+        vm.skip(!forkEnabled);
+        _;
+    }
+
+    /// @notice This suite never touches the mainnet rewards vault.
+    function test_fork_refusesMainnetVault() public onlyFork {
+        assertEq(address(vault), PROXY, "fork: not the Sepolia proxy");
+        assertTrue(address(vault) != MAINNET_VAULT, "fork: pointed at mainnet");
+        assertEq(address(vault.asset()), SAPIEN, "fork: asset() != Sepolia SAPIEN");
+    }
+
+    /// @notice Live `SEPOLIA_ENGINE` (if configured) already holds `ENGINE_ROLE`.
+    function test_fork_liveEngineRole() public onlyFork {
+        address liveEngine = vm.envOr("SEPOLIA_ENGINE", address(0));
+        if (liveEngine == address(0)) return;
+        assertTrue(vault.hasRole(vault.ENGINE_ROLE(), liveEngine), "fork: SEPOLIA_ENGINE missing ENGINE_ROLE");
+    }
+
+    /// @notice AC1: deposit Sepolia SAPIEN, wait `minDepositAge`, `lockStake`.
+    ///         The fork-local engine (and, if set, `SEPOLIA_ENGINE`) holds the role.
+    function test_fork_depositWaitLock() public onlyFork {
+        assertTrue(vault.hasRole(vault.ENGINE_ROLE(), engine), "fork: test engine missing ENGINE_ROLE");
+        assertFalse(vault.paused(), "fork: vault paused");
+
+        address validator = makeAddr("sepoliaValidator");
+        _depositAndMature(validator);
+
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+
+        StakeAccount memory acct = vault.getStakeAccount(validator);
+        assertEq(acct.lockedAmount, LOCK, "fork: lockedAmount != lock");
+    }
+
+    /// @notice AC2: accepted review → `unlockStake` → `report.stake` fields.
+    function test_fork_acceptedReview_unlock() public onlyFork {
+        address validator = makeAddr("sepoliaHappy");
+        _depositAndMature(validator);
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+
+        uint256 lockedAtReview = vault.getStakeAccount(validator).lockedAmount;
+        assertEq(lockedAtReview, LOCK);
+
+        vm.expectEmit(true, true, false, true, PROXY);
+        emit ISapienVault.StakeUnlocked(validator, LOCK);
+
+        vm.prank(engine);
+        vault.unlockStake(validator, LOCK);
+
+        CollateralReport.Stake memory stake = CollateralReport.accepted(lockedAtReview);
+        assertEq(stake.slashedWei, 0, "fork: stake.slashed_wei != 0");
+        assertEq(stake.stakeAtRiskWei, lockedAtReview, "fork: stake.stake_at_risk_wei != locked at review");
+        assertEq(vault.getStakeAccount(validator).lockedAmount, 0, "fork: lock not cleared");
+    }
+
+    /// @notice AC3: `slashStake` burns shares (`SharesSlashed`); report + Basescan URL.
+    function test_fork_forcedReview_slash() public onlyFork {
+        address validator = makeAddr("sepoliaForced");
+        _depositAndMature(validator);
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+
+        uint256 lockedAtReview = vault.getStakeAccount(validator).lockedAmount;
+        uint256 sharesBefore = vault.balanceOf(validator);
+
+        vm.recordLogs();
+        vm.prank(engine);
+        vault.slashStake(validator, LOCK);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bool sawSlash;
+        bool sawShares;
+        for (uint256 i; i < logs.length; ++i) {
+            if (logs[i].emitter != PROXY) continue;
+            if (logs[i].topics[0] == ISapienVault.StakeSlashed.selector) {
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), validator);
+                assertEq(uint256(logs[i].topics[2]), LOCK, "fork: StakeSlashed.amount != burned assets");
+                sawSlash = true;
+            }
+            if (logs[i].topics[0] == ISapienVault.SharesSlashed.selector) {
+                assertEq(address(uint160(uint256(logs[i].topics[1]))), validator);
+                assertGt(uint256(logs[i].topics[2]), 0, "fork: SharesSlashed.shares == 0");
+                sawShares = true;
+            }
+        }
+        assertTrue(sawSlash, "fork: missing StakeSlashed");
+        assertTrue(sawShares, "fork: missing SharesSlashed");
+        assertLt(vault.balanceOf(validator), sharesBefore, "fork: slash did not burn shares");
+
+        CollateralReport.Stake memory stake = CollateralReport.slashed(LOCK, lockedAtReview);
+        assertEq(stake.slashedWei, LOCK, "fork: stake.slashed_wei != burned asset amount");
+        assertEq(stake.stakeAtRiskWei, lockedAtReview, "fork: stake.stake_at_risk_wei != locked at review");
+        assertEq(vault.getStakeAccount(validator).lockedAmount, 0, "fork: lock not reduced");
+
+        // HTML report link. On a fork there is no explorer tx; the helper still
+        // produces the Basescan Sepolia URL the engine will emit for the live tx.
+        bytes32 example = bytes32(uint256(0x167));
+        assertEq(
+            CollateralReport.sepoliaTxUrl(example),
+            "https://sepolia.basescan.org/tx/0x0000000000000000000000000000000000000000000000000000000000000167"
+        );
+    }
+
+    /// @notice Owner cannot self-unlock / self-slash on the live proxy ABI.
+    function test_fork_unlockSlash_onlyEngine() public onlyFork {
+        address validator = makeAddr("sepoliaAuth");
+        _depositAndMature(validator);
+        vm.prank(validator);
+        vault.lockStake(LOCK);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, validator, vault.ENGINE_ROLE()
+            )
+        );
+        vm.prank(validator);
+        vault.unlockStake(validator, LOCK);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, validator, vault.ENGINE_ROLE()
+            )
+        );
+        vm.prank(validator);
+        vault.slashStake(validator, LOCK);
+    }
+
+    function _depositAndMature(address validator) internal {
+        deal(SAPIEN, validator, DEPOSIT);
+        vm.startPrank(validator);
+        IERC20(SAPIEN).approve(PROXY, DEPOSIT);
+        uint256 shares = vault.deposit(DEPOSIT, validator);
+        vm.stopPrank();
+        assertGt(shares, 0, "fork: deposit minted no shares");
+
+        if (vault.minDepositAge() > 0) {
+            assertEq(vault.maturedShares(validator), 0, "fork: fresh deposit already mature");
+            vm.prank(validator);
+            vm.expectRevert(abi.encodeWithSelector(ISapienVault.InsufficientAvailableBalance.selector, LOCK, 0));
+            vault.lockStake(LOCK);
+            skip(vault.minDepositAge());
+        }
+
+        assertGt(vault.availableBalance(validator), 0, "fork: nothing available after maturity");
+    }
+}

--- a/test/fork/SepoliaCollateralLoop.t.sol
+++ b/test/fork/SepoliaCollateralLoop.t.sol
@@ -54,8 +54,9 @@ contract SepoliaCollateralLoopTest is Test {
 
         // Fork-local grant so unlock/slash can run even before the Safe
         // submits `GrantEngineRole` calldata on the live vault.
+        bytes32 engineRole = vault.ENGINE_ROLE();
         vm.prank(admin);
-        vault.grantRole(vault.ENGINE_ROLE(), engine);
+        vault.grantRole(engineRole, engine);
     }
 
     modifier onlyFork() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #167.

Wires the **Sepolia** lock → review → unlock or slash loop. The vault ABI is unchanged: no scoring, quorum, or consensus functions. Mainnet vault `0x60Bf63729f688287a450299962b36Cef0aFfaa42` and the 20% rewards program are untouched (`deployments/base-mainnet.json`, `test/fork/UpgradeFork.t.sol`, and `src/SapienVault.sol` are unmodified). Engine `report.stake` emission is poq-monorepo #1760 (not this repo).

## What landed

- **`script/GrantEngineRole.s.sol`** — prints Safe `grantRole(ENGINE_ROLE, SEPOLIA_ENGINE)` calldata for the live Sepolia UUPS `0x58E72Fa7fb92B100f2c652377465EEEe2642544C`. Refuses the mainnet vault. `VERIFY_ONLY=true` checks the live role.
- **`docs/SepoliaCollateralLoop.md`** — observer checklist: Basescan Sepolia vs `report.stake` (`slashed_wei`, `stake_at_risk_wei`) and the HTML slash-tx URL.
- **Tests**
  - `test/CollateralLoop.t.sol` (CI): deposit → wait default `minDepositAge` → `lockStake`; accepted → `unlockStake` → `slashed_wei = 0`; forced → `slashStake` emits `SharesSlashed` and `slashed_wei` equals the burned asset amount.
  - `test/fork/SepoliaCollateralLoop.t.sol`: same loop on a fork of the live V2 proxy (skips without `BASE_SEPOLIA_RPC_URL`). Grants a fork-local engine so the loop runs before the Safe grant lands; if `SEPOLIA_ENGINE` is set, asserts that address already holds the role.
  - `test/SapienVaultNoConsensus.t.sol`: fails if `computeConsensus` / `score` / `quorum` functions are added; pins mainnet + Sepolia deployment addresses.

## Operator grant (Safe)

Live Sepolia vault currently has **no** `ENGINE_ROLE` member. After this merges, the admin Safe submits the grant:

```bash
export BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
export SEPOLIA_ENGINE=0x...   # staging engine signer
make grant-engine-sepolia-calldata
# Safe: target = 0x58E72Fa7…, value 0, paste calldata
make grant-engine-sepolia-verify
```

## Test plan

- [x] `forge test --match-contract CollateralLoopTest` — 4/4
- [x] `forge test --match-contract SapienVaultNoConsensusTest` — 4/4
- [x] `FOUNDRY_PROFILE=ci forge test --no-match-path 'test/halmos/**'` — existing unit/audit/invariant suites green; fork suites skip without RPC
- [x] `BASE_SEPOLIA_RPC_URL=https://sepolia.base.org` fork loop — 6/6 on the live V2 proxy (deposit/age/lock, unlock `slashed_wei=0`, slash `SharesSlashed`, engine-only, mainnet refused)
- [x] `GrantEngineRole` with `VAULT_PROXY` = mainnet reverts `mainnet vault is untouchable`; Sepolia prints `grantRole` calldata
- [x] `deployments/base-mainnet.json`, `test/fork/UpgradeFork.t.sol`, `src/SapienVault.sol` unchanged vs `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7821e72b-db42-427f-ab4d-e5659fcddb3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7821e72b-db42-427f-ab4d-e5659fcddb3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

